### PR TITLE
adjust perf rotation timeout to avoid high memory usage

### DIFF
--- a/gprofiler/profilers/perf.py
+++ b/gprofiler/profilers/perf.py
@@ -190,7 +190,10 @@ class SystemProfiler(ProfilerBase):
         self._node_processes: List[Process] = []
         self._node_processes_attached: List[Process] = []
         self._perf_memory_restart = perf_memory_restart
-        switch_timeout_s = duration * 3  # allow gprofiler to be delayed up to 3 intervals before timing out.
+        # allow gprofiler to be delayed up to 3 intervals before timing out.
+        # For low-frequency profiling, use shorter switch intervals to reduce memory buildup
+        # But maintain reasonable safety margin to avoid premature rotations
+        switch_timeout_s = duration * 1.5 if frequency <= 11 else duration * 3
         extra_args = []
         try:
             # We want to be certain that `perf record` will collect samples.

--- a/gprofiler/utils/perf_process.py
+++ b/gprofiler/utils/perf_process.py
@@ -31,8 +31,8 @@ def perf_path() -> str:
 # TODO: automatically disable this profiler if can_i_use_perf_events() returns False?
 class PerfProcess:
     _DUMP_TIMEOUT_S = 5  # timeout for waiting perf to write outputs after signaling (or right after starting)
-    _RESTART_AFTER_S = 3600
-    _PERF_MEMORY_USAGE_THRESHOLD = 512 * 1024 * 1024
+    _RESTART_AFTER_S = 600  # 10 minutes - more aggressive for higher frequency profiling
+    _PERF_MEMORY_USAGE_THRESHOLD = 200 * 1024 * 1024  # 200MB - lower threshold for high memory consumption
     # default number of pages used by "perf record" when perf_event_mlock_kb=516
     # we use double for dwarf.
     _MMAP_SIZES = {"fp": 129, "dwarf": 257}


### PR DESCRIPTION

## Description
Perf is highest contributor for memory. 
Unlike runtime profilers, perf does not restart due to perf start up takes ~2-5s. So there is an opportunity to reduce the restart time and memory threshold




## Motivation and Context
<!--- Why is this change required? What problem does it solve? What does it improve? -->

## How Has This Been Tested?
u18, u20, u24 on x86_64, arm_64

Also with different frequencies 

## Screenshots
<!--- (if appropriate) -->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have updated the relevant documentation.
- [ ] I have added tests for new logic.
