### PR TITLE
resolve memory issue on heartbeat stop

### DIFF
--- a/gprofiler/heartbeat.py
+++ b/gprofiler/heartbeat.py
@@ -288,6 +288,12 @@ class DynamicGProfilerManager:
             logger.info("STOPPING current gProfiler instance...")
             try:
                 self.current_gprofiler.stop()  # This sets the stop_event!
+                
+                # MISSING: Add comprehensive cleanup like in continuous mode
+                logger.debug("Starting comprehensive cleanup after heartbeat stop...")
+                self.current_gprofiler.maybe_cleanup_subprocesses()
+                logger.debug("Comprehensive cleanup completed")
+                
                 logger.info("Successfully called gprofiler.stop()")
             except Exception as e:
                 # TODO: This is a huge leak, report it  

--- a/gprofiler/main.py
+++ b/gprofiler/main.py
@@ -309,10 +309,26 @@ class GProfiler:
     def stop(self) -> None:
         logger.info("Stopping ...")
         self._profiler_state.stop_event.set()
-        self._system_metrics_monitor.stop()
-        self._hw_metrics_monitor.stop()
+        
+        # Stop system metrics monitor with exception protection
+        try:
+            self._system_metrics_monitor.stop()
+        except Exception as e:
+            logger.error(f"Error stopping system metrics monitor: {e}")
+        
+        # Stop hardware metrics monitor with exception protection
+        try:
+            self._hw_metrics_monitor.stop()
+        except Exception as e:
+            logger.error(f"Error stopping hardware metrics monitor: {e}")
+        
+        # Stop all profilers with individual exception protection
         for prof in self.all_profilers:
-            prof.stop()
+            try:
+                prof.stop()
+                logger.debug(f"Successfully stopped profiler: {prof.name}")
+            except Exception as e:
+                logger.error(f"Error stopping profiler {prof.name}: {e}")
 
     def _snapshot(self) -> None:   
         local_start_time = datetime.datetime.utcnow()


### PR DESCRIPTION

## Description
Make sure processes are cleaned up after stopping gprofiler from command control 




## Motivation and Context
memory utilization control with command control

## How Has This Been Tested?
in progress - arm64, x86_64 

`
--enable-heartbeat-server --api-server=$GPROFILER_SERVER"
`

## Screenshots
<!--- (if appropriate) -->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [x] I have updated the relevant documentation.
- [ ] I have added tests for new logic.
