### PR TITLE
Make heartbeat perf profiling limits configurable via CLI

### DIFF
--- a/gprofiler/dynamic_profiling_management/__init__.py
+++ b/gprofiler/dynamic_profiling_management/__init__.py
@@ -127,21 +127,21 @@ def _apply_profiler_configs(new_args: configargparse.Namespace, profiler_configs
         perf_events = validate_and_normalize_events(perf_events)
 
         if perf_mode == "enabled_restricted":
-            new_args.max_system_processes_for_system_profilers = 600
-            new_args.perf_max_docker_containers = 2
+            new_args.max_system_processes_for_system_profilers = new_args.heartbeat_perf_restricted_max_system_processes
+            new_args.perf_max_docker_containers = new_args.heartbeat_perf_restricted_max_docker_containers
         elif perf_mode == "enabled_aggressive":
-            new_args.max_system_processes_for_system_profilers = 1500
-            new_args.perf_max_docker_containers = 50
+            new_args.max_system_processes_for_system_profilers = new_args.heartbeat_perf_aggressive_max_system_processes
+            new_args.perf_max_docker_containers = new_args.heartbeat_perf_aggressive_max_docker_containers
         elif perf_mode == "disabled":
             new_args.perf_mode = "disabled"
         new_args.perf_events = ",".join(perf_events)
     else:
         if perf_config == "enabled_restricted":
-            new_args.max_system_processes_for_system_profilers = 600
-            new_args.perf_max_docker_containers = 2
+            new_args.max_system_processes_for_system_profilers = new_args.heartbeat_perf_restricted_max_system_processes
+            new_args.perf_max_docker_containers = new_args.heartbeat_perf_restricted_max_docker_containers
         elif perf_config == "enabled_aggressive":
-            new_args.max_system_processes_for_system_profilers = 1500
-            new_args.perf_max_docker_containers = 50
+            new_args.max_system_processes_for_system_profilers = new_args.heartbeat_perf_aggressive_max_system_processes
+            new_args.perf_max_docker_containers = new_args.heartbeat_perf_aggressive_max_docker_containers
         elif perf_config == "disabled":
             new_args.perf_mode = "disabled"
         new_args.perf_events = "cycles"

--- a/gprofiler/main.py
+++ b/gprofiler/main.py
@@ -1202,6 +1202,42 @@ def parse_cmd_args() -> configargparse.Namespace:
         help="Interval in seconds for sending heartbeats to server (default: %(default)s)",
     )
 
+    parser.add_argument(
+        "--heartbeat-perf-restricted-max-processes",
+        type=positive_integer,
+        dest="heartbeat_perf_restricted_max_system_processes",
+        default=600,
+        help="Max system processes threshold applied to perf when the heartbeat command uses"
+        " 'enabled_restricted' mode (default: %(default)s)",
+    )
+
+    parser.add_argument(
+        "--heartbeat-perf-restricted-max-containers",
+        type=positive_integer,
+        dest="heartbeat_perf_restricted_max_docker_containers",
+        default=2,
+        help="Max Docker containers to profile when the heartbeat command uses"
+        " 'enabled_restricted' mode (default: %(default)s)",
+    )
+
+    parser.add_argument(
+        "--heartbeat-perf-aggressive-max-processes",
+        type=positive_integer,
+        dest="heartbeat_perf_aggressive_max_system_processes",
+        default=1500,
+        help="Max system processes threshold applied to perf when the heartbeat command uses"
+        " 'enabled_aggressive' mode (default: %(default)s)",
+    )
+
+    parser.add_argument(
+        "--heartbeat-perf-aggressive-max-containers",
+        type=positive_integer,
+        dest="heartbeat_perf_aggressive_max_docker_containers",
+        default=50,
+        help="Max Docker containers to profile when the heartbeat command uses"
+        " 'enabled_aggressive' mode (default: %(default)s)",
+    )
+
     if is_linux() and not is_aarch64():
         hw_metrics_options = parser.add_argument_group("hardware metrics")
         hw_metrics_options.add_argument(


### PR DESCRIPTION
# Make heartbeat perf profiling limits configurable via CLI

## Summary

The thresholds applied to perf when the heartbeat/dynamic profiling system receives an
`enabled_restricted` or `enabled_aggressive` profiling command were previously hardcoded.
This PR exposes them as CLI arguments so operators can tune the limits to their environment
without rebuilding or patching the agent.

## Background

When gProfiler receives a heartbeat command from the server, `_apply_profiler_configs`
translates the `perf` profiling mode into concrete resource limits:

| Mode | `max_system_processes_for_system_profilers` | `perf_max_docker_containers` |
|---|---|---|
| `enabled_restricted` | 600 | 2 |
| `enabled_aggressive` | 1500 | 50 |

These values were hardcoded, making it impossible to adjust them without a code change.

## Changes

### `gprofiler/main.py`

Four new CLI arguments added in the heartbeat argument group:

| Flag | `dest` | Default |
|---|---|---|
| `--heartbeat-perf-restricted-max-processes` | `heartbeat_perf_restricted_max_system_processes` | `600` |
| `--heartbeat-perf-restricted-max-containers` | `heartbeat_perf_restricted_max_docker_containers` | `2` |
| `--heartbeat-perf-aggressive-max-processes` | `heartbeat_perf_aggressive_max_system_processes` | `1500` |
| `--heartbeat-perf-aggressive-max-containers` | `heartbeat_perf_aggressive_max_docker_containers` | `50` |

The `--heartbeat-perf-*` prefix distinguishes these from `--perf-*` arguments, which belong
to the perf profiler registry and control profiler behaviour directly.

### `gprofiler/dynamic_profiling_management/__init__.py`

`_apply_profiler_configs` now reads the four limits from `new_args` (which is already
initialised as a copy of the parsed CLI `base_args`) instead of using hardcoded literals.
Both the dict-style and string-style perf config branches are updated.

No changes to `DynamicGProfilerManager`, `HeartbeatClient`, or `create_profiler_args`
signatures were needed — the values flow through automatically via the existing
`base_args → new_args` copy.

## Backwards Compatibility

The defaults for all four new arguments match the previous hardcoded values exactly, so
existing deployments that do not pass these flags are unaffected.

## Testing

- Verified locally that the new flags are accepted and override the applied limits when a
  heartbeat command arrives with `enabled_restricted` / `enabled_aggressive` perf modes.
- Verified that omitting the flags produces the same behaviour as before.

