### PR TITLE
Add workload heartbeat inventory and design spec

### DIFF
--- a/.claude/skills/architecture/SKILL.md
+++ b/.claude/skills/architecture/SKILL.md
@@ -1,0 +1,81 @@
+---
+name: architecture
+description: Understand gProfiler architecture and codebase structure. Use when the user asks how gProfiler works, wants to understand the codebase, or needs architectural guidance.
+context: fork
+user-invocable: true
+---
+
+## gProfiler Architecture Overview
+
+gProfiler now has two important paths:
+
+1. **Classic profiling path**: discover processes -> select profilers -> collect samples -> merge -> output/upload
+2. **Dynamic profiling control path**: heartbeat with backend -> receive commands -> queue/prioritize -> run continuous or ad-hoc profiling -> report completion
+
+When answering architecture questions, identify which path the request touches before reading or editing code.
+
+### Main architecture areas
+
+| Area | Primary files | What belongs here |
+|------|---------------|-------------------|
+| CLI + orchestration | `gprofiler/main.py` (~1546) | Argument parsing, runtime wiring, top-level orchestration. Treat as a hotspot; avoid broad edits if a narrower seam exists. |
+| Profiler registration + lifecycle | `gprofiler/profilers/registry.py`, `gprofiler/profilers/profiler_base.py` | Registration, mode selection, `start()` / `snapshot()` / `stop()` lifecycle. |
+| Runtime profilers | `gprofiler/profilers/*.py` | Runtime/tool-specific logic: process discovery, sampling, stack parsing, cleanup. |
+| Merge/output | `gprofiler/merge.py` (~330) | Stack aggregation, symbol handling, output shaping. |
+| Metadata enrichment | `gprofiler/metadata/` | Application identifiers and host/system metadata. |
+| Dynamic profiling command control | `gprofiler/dynamic_profiling_management/heartbeat.py` (~354), `command_control.py` (~233), `continuous.py` (~68), `ad_hoc.py` (~76) | Heartbeat polling, command parsing, queue priority, pause/resume, execution routing. |
+| Shared test infrastructure | `tests/conftest.py` (~708) | Docker fixtures, runtime builders, cleanup. Shared and regression-sensitive. |
+
+### Runtime profilers
+
+| Profiler | Backend tool | Notes |
+|----------|--------------|-------|
+| `perf.py` | Linux perf | System-wide profiling, kernel/user stacks |
+| `java.py` | async-profiler | JVM attach, allocation profiling, large hotspot (~1555 lines) |
+| `python.py` | py-spy | Python sampling without instrumentation |
+| `python_ebpf.py` | PyPerf | eBPF-based Python profiling |
+| `ruby.py` | rbspy | Ruby VM sampling |
+| `php.py` | phpspy | PHP process profiling |
+| `dotnet.py` | dotnet-trace | .NET support |
+| `node.py` | perf | Node/V8 profiling |
+
+### Classic profiling data flow
+
+```text
+1. Discover target processes
+2. Select profilers / modes
+3. Each profiler samples independently
+4. merge.py aggregates results
+5. Output collapsed stacks, flamegraph data, or upload results
+```
+
+### Dynamic profiling control flow
+
+```text
+1. Backend receives profiling request
+2. Agent heartbeat polls for work
+3. heartbeat.py parses command payload
+4. command_control.py enqueues by priority
+5. continuous.py or ad_hoc.py executes the command
+6. Agent reports command completion
+```
+
+Priority is `stop > adhoc > continuous`. Do not describe or implement a parallel control path unless the existing heartbeat/queue system is truly insufficient.
+
+### Where to make changes
+
+- **Add a new profiler**: new file under `gprofiler/profilers/`, register via `@register_profiler`, add targeted tests.
+- **Change profiler behavior**: edit the specific profiler first; avoid `main.py` unless CLI/wiring must change.
+- **Change merge or output**: start in `gprofiler/merge.py`.
+- **Change heartbeat / dynamic profiling**: start in `gprofiler/dynamic_profiling_management/`.
+- **Change shared test behavior**: touch `tests/conftest.py` only when multiple tests need new shared infra.
+
+### Guidance when answering users
+
+1. Start with the smallest relevant architecture slice, not the whole repo.
+2. If the request is about command-driven profiling, include the heartbeat + queue modules, not just `main.py`.
+3. Call out hotspot files when relevant:
+   - `gprofiler/main.py` (~1546)
+   - `gprofiler/profilers/java.py` (~1555)
+   - `tests/conftest.py` (~708)
+4. Prefer concrete file references over generic descriptions.

--- a/.claude/skills/arm-support/SKILL.md
+++ b/.claude/skills/arm-support/SKILL.md
@@ -1,0 +1,162 @@
+---
+name: arm-support
+description: Debug and fix ARM/Aarch64 compatibility issues. Use when the user encounters ARM-specific bugs or needs to add ARM support for a feature.
+---
+
+## ARM/Aarch64 Support Guide
+
+**Context from history:** ARM issues are recurring (6+ commits fixing ARM-specific bugs in 3 years).
+
+### Architecture Support Status
+
+| Runtime | x86_64 | Aarch64 |
+|---------|--------|---------|
+| perf (native, Golang) | ✅ | ✅ |
+| Java (async-profiler) | ✅ | ✅ |
+| Python (py-spy) | ✅ | ✅ |
+| Python (PyPerf eBPF) | ✅ | ❌ |
+| Ruby (rbspy) | ✅ | ✅ |
+| PHP (phpspy) | ✅ | ✅ (experimental) |
+| NodeJS (perf) | ✅ | ✅ |
+| .NET (dotnet-trace) | ✅ (exp) | ✅ (exp) |
+
+### Common ARM Issues from History
+
+**1. gProfiler ARM Build Failures**
+```
+# Commit: [Reliability] Fix gProfiler arm (#988)
+# Commit: Fixes #977 gprofiler does not work on aarch64 (#978)
+```
+
+**2. Architecture Metadata**
+```
+# Commit: Fix arch metadata with Aarch64 (#837)
+# Issue: Incorrect architecture reporting
+```
+
+**3. getaddrinfo() EBUSY**
+```
+# Commit: Fix getaddrinfo() EBUSY on ARM (#825)
+# Issue: Network resolution fails intermittently on ARM
+```
+
+**4. Perf Build on ARM**
+```
+# Commit: Perf: fix v6.7 build on aarch64 (#891)
+# Issue: perf tool compilation differences
+```
+
+### Checking Architecture
+
+```bash
+# Check current architecture
+uname -m
+# x86_64 or aarch64
+
+# In Python
+import platform
+platform.machine()
+```
+
+### Building for ARM
+
+```bash
+# Native ARM build (on ARM host)
+./scripts/build_aarch64_container.sh -t gprofiler:arm64
+./scripts/build_aarch64_executable.sh
+
+# Cross-build from x86_64 (slow, requires QEMU)
+docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
+docker buildx create --name multiarch --driver docker-container --use
+./scripts/build_aarch64_container.sh -t gprofiler:arm64
+```
+
+### Testing on ARM
+
+```bash
+# Run tests on ARM host
+cd tests && sudo python3 -m pytest -v
+
+# Skip x86_64-only tests
+cd tests && sudo python3 -m pytest -v -k "not x86_64_only"
+
+# Check for ARM-specific test markers
+grep -r "aarch64\|arm64" tests/
+```
+
+### ARM-Specific Code Patterns
+
+```python
+import platform
+
+def is_aarch64() -> bool:
+    return platform.machine() in ("aarch64", "arm64")
+
+# Conditional logic for ARM
+if is_aarch64():
+    # ARM-specific handling
+    pass
+```
+
+### Key Files for ARM Support
+
+```
+gprofiler/utils/          # Architecture detection utilities
+scripts/build_aarch64_*   # ARM build scripts
+tests/conftest.py         # Test fixtures with arch detection
+```
+
+### Debugging ARM Issues
+
+```bash
+# Check kernel version (ARM may have different capabilities)
+uname -r
+
+# Check perf support
+perf list
+
+# Check CPU info
+cat /proc/cpuinfo | head -20
+
+# Check if running in container
+cat /proc/1/cgroup
+```
+
+### PyPerf/eBPF on ARM
+
+**Note:** PyPerf (eBPF-based Python profiler) is NOT supported on ARM.
+
+```python
+# From gprofiler/profilers/python_ebpf.py
+# PyPerf requires x86_64
+if is_aarch64():
+    # Fall back to py-spy
+    pass
+```
+
+### CI/CD for ARM
+
+`.github/workflows/build-test-deploy.yml`:
+- Separate jobs for x86_64 and aarch64
+- ARM builds use different runner labels
+- Some tests may be skipped on ARM
+
+### Commit Message Pattern
+
+```
+Fix <issue> on ARM/Aarch64 (#PR_NUMBER)
+[Reliability] Fix gProfiler arm (#PR_NUMBER)
+```
+
+---
+
+## TODO: Skill Content to Add
+
+- [ ] **Add complete ARM compatibility table** - All profilers × ARM status
+- [ ] **Add ARM kernel requirements** - Minimum kernel versions for features
+- [ ] **Add Graviton-specific notes** - AWS Graviton 2/3 specific issues
+- [ ] **Add ARM perf event support** - Which perf events work on ARM
+- [ ] **Add ARM Docker tips** - Multi-arch build best practices
+- [ ] **Add ARM test infrastructure** - How to run ARM tests locally
+- [ ] **Add cross-compile troubleshooting** - Common QEMU issues
+- [ ] **Add ARM cloud provider notes** - AWS, GCP, Azure ARM instances

--- a/.claude/skills/ci-status/SKILL.md
+++ b/.claude/skills/ci-status/SKILL.md
@@ -1,0 +1,90 @@
+---
+name: ci-status
+description: Check CI pipeline status and troubleshoot failures. Use when the user wants to check build status, see why CI failed, or monitor workflow runs.
+allowed-tools: Bash(gh *) Bash(git *)
+---
+
+## gProfiler CI/CD Status
+
+### Current PR/Branch Status
+
+```!
+BRANCH=$(git branch --show-current)
+echo "Branch: $BRANCH"
+echo ""
+# Try to get PR status
+gh pr view --json state,statusCheckRollup,url 2>/dev/null || echo "No PR found for this branch"
+```
+
+### CI Workflows
+
+| Workflow | Triggers | Purpose |
+|----------|----------|---------|
+| `linters.yml` | PR, push | Python/Shell/Dockerfile linting |
+| `build-test-deploy.yml` | PR, push, schedule | Build & test executables/containers |
+| `codeql.yml` | PR, push, schedule | Security scanning |
+| `build-base-images.yml` | Manual | Base Docker image builds |
+
+### Check Commands
+
+```bash
+# View PR checks
+gh pr checks
+
+# Watch checks until complete
+gh pr checks --watch
+
+# List recent workflow runs
+gh run list --limit 10
+
+# View specific run details
+gh run view <run-id>
+
+# View failed run logs
+gh run view <run-id> --log-failed
+
+# Re-run failed jobs
+gh run rerun <run-id> --failed
+```
+
+### Common CI Failures
+
+#### Linting Failures
+```bash
+# Fix locally
+./lint.sh          # Auto-format
+./lint.sh --ci     # Check mode (what CI runs)
+mypy .             # Type check
+```
+
+#### Build Failures
+- Check Docker layer caching
+- Verify base image availability
+- Check for network/download issues
+
+#### Test Failures
+```bash
+# Run specific failing test locally
+sudo python3 -m pytest tests/test_<name>.py -v -k "test_name"
+```
+
+### Instructions
+
+1. Check current CI status with commands above
+2. If failed, identify which job failed
+3. Fetch logs with `gh run view <id> --log-failed`
+4. Suggest fixes based on error messages
+5. Help re-run if it was a flaky failure
+
+---
+
+## TODO: Skill Content to Add
+
+- [ ] **Add workflow file documentation** - Explain each workflow file
+- [ ] **Add job dependency diagram** - Visual CI pipeline flow
+- [ ] **Add runner specifications** - What runs on which runner type
+- [ ] **Add common failure patterns** - Categorized CI failure examples
+- [ ] **Add cache configuration** - How Docker layer caching works
+- [ ] **Add artifact retention** - Where build artifacts are stored
+- [ ] **Add required checks list** - Which checks must pass for merge
+- [ ] **Add workflow dispatch guide** - How to manually trigger workflows

--- a/.claude/skills/debug/SKILL.md
+++ b/.claude/skills/debug/SKILL.md
@@ -1,0 +1,79 @@
+---
+name: debug
+description: Debug profiler issues and analyze errors. Use when the user encounters errors, crashes, or unexpected behavior in gProfiler.
+allowed-tools: Bash(python3 *) Bash(strace *) Bash(sudo *) Bash(dmesg *) Bash(journalctl *) Read Grep Glob
+---
+
+## gProfiler Debugging Guide
+
+### System Context
+
+```!
+uname -a
+python3 --version
+cat /etc/os-release 2>/dev/null | head -5
+```
+
+### Common Debug Commands
+
+#### Check Profiler Dependencies
+```bash
+# Verify perf is available
+which perf && perf --version
+
+# Check kernel capabilities
+cat /proc/sys/kernel/perf_event_paranoid
+cat /proc/sys/kernel/kptr_restrict
+
+# Check CAP_SYS_ADMIN capability
+capsh --print 2>/dev/null | grep -i sys_admin
+```
+
+#### Debug Running gProfiler
+```bash
+# Run with verbose logging
+sudo python3 -m gprofiler -v --output-dir /tmp/gprofiler-debug
+
+# Trace system calls
+sudo strace -f -o /tmp/gprofiler.strace python3 -m gprofiler ...
+
+# Check for permission issues
+sudo dmesg | tail -50 | grep -i "permission\|denied\|perf"
+```
+
+#### Profiler-Specific Debugging
+
+| Profiler | Debug Flag | Log Location |
+|----------|------------|--------------|
+| perf | `--perf-mode=fp` | stderr |
+| Java | `--java-async-profiler-mode=cpu` | `/tmp/async-profiler.log` |
+| Python | `--python-mode=pyperf` | stderr |
+| Ruby | `--ruby-mode=rbspy` | stderr |
+
+### Common Issues
+
+1. **"perf_event_open failed"** - Check `/proc/sys/kernel/perf_event_paranoid` (should be ≤1)
+2. **"Permission denied"** - Run with sudo or check capabilities
+3. **"No samples collected"** - Process may be idle or profiler incompatible
+4. **Container issues** - Check `--privileged` or `SYS_ADMIN` capability
+
+### Instructions
+
+1. Gather error messages and stack traces
+2. Check system requirements above
+3. Identify which profiler is failing
+4. Review relevant profiler code in `gprofiler/profilers/`
+5. Suggest fixes or workarounds
+
+---
+
+## TODO: Skill Content to Add
+
+- [ ] **Add error message catalog** - Common errors with solutions
+- [ ] **Add kernel version requirements** - Minimum kernel for each feature
+- [ ] **Add container runtime matrix** - Docker/containerd/cri-o compatibility
+- [ ] **Add perf_event_paranoid guide** - All levels and their effects
+- [ ] **Add capability requirements** - Required Linux capabilities per profiler
+- [ ] **Add log file locations** - Where to find all log files
+- [ ] **Add strace interpretation** - How to read strace output for gProfiler
+- [ ] **Add profiler-specific debug flags** - Debug options per profiler

--- a/.claude/skills/dependency-update/SKILL.md
+++ b/.claude/skills/dependency-update/SKILL.md
@@ -1,0 +1,160 @@
+---
+name: dependency-update
+description: Safely update Python dependencies with security and compatibility checks. Use when the user wants to update packages, fix CVEs, or upgrade dependencies.
+allowed-tools: Bash(pip *) Bash(pip3 *) Bash(python3 -m pip *) Bash(safety *) Bash(pip-audit *) Read Edit Grep
+---
+
+## gProfiler Dependency Management
+
+**Context from history:** 26% of all commits (41/156) are dependency updates. Security-first approach.
+
+### Current Dependencies
+
+```!
+echo "=== requirements.txt (runtime) ==="
+head -15 requirements.txt 2>/dev/null || echo "File not found"
+echo ""
+echo "=== dev-requirements.txt (development) ==="
+head -15 dev-requirements.txt 2>/dev/null || echo "File not found"
+```
+
+### CVE Fixes from History
+
+| CVE | Package | Fix Commit |
+|-----|---------|------------|
+| CVE-2025-71176 | pytest | Update pytest to 9.0.3 (#1035) |
+| CVE (black) | black | Fix CVE issue from black package (#1023) |
+| Security | requests | Update requests to 2.33.0 (#1032) |
+| Security | grpcio | Update granulate-utils reference (#989) |
+
+### Security Scanning
+
+```bash
+# Using pip-audit (recommended)
+pip install pip-audit
+pip-audit -r requirements.txt
+pip-audit -r dev-requirements.txt
+
+# Using safety
+pip install safety
+safety check -r requirements.txt
+
+# Using bandit for code security
+pip install bandit
+bandit -r gprofiler/
+```
+
+### Update Workflow
+
+**Step 1: Check for vulnerabilities**
+```bash
+pip-audit -r requirements.txt
+```
+
+**Step 2: Check outdated packages**
+```bash
+pip list --outdated
+```
+
+**Step 3: Update specific package**
+```bash
+# Check current version
+pip show <package>
+
+# Check available versions
+pip index versions <package>
+
+# Edit requirements file
+# Then test:
+pip install -r requirements.txt -r dev-requirements.txt
+```
+
+**Step 4: Verify compatibility**
+```bash
+./lint.sh
+mypy .
+cd tests && sudo python3 -m pytest -v test_sanity.py
+```
+
+### Key Dependencies
+
+| Package | File | Purpose | Update Frequency |
+|---------|------|---------|------------------|
+| `psutil` | requirements.txt | Process utilities | Stable |
+| `requests` | requirements.txt | HTTP client | Security-sensitive |
+| `granulate-utils` | requirements.txt | Shared utilities | Internal |
+| `pytest` | dev-requirements.txt | Testing | Security-sensitive |
+| `black` | dev-requirements.txt | Formatting | CVE history |
+| `mypy` | dev-requirements.txt | Type checking | Regular |
+| `flake8` | dev-requirements.txt | Linting | Stable |
+
+### Base Image Dependencies
+
+From history, these also get updated:
+- Alpine version (v3.22 → v3.23)
+- OpenSSL version (v3.0.11)
+- zlib version (1.3 → 1.3.1)
+
+Check Dockerfiles:
+```bash
+grep -E "FROM|apk add|apt-get" container.Dockerfile executable.Dockerfile
+```
+
+### Commit Message Pattern
+
+For security updates:
+```
+Update <package> to <version> to fix CVE-XXXX-XXXXX (#PR)
+```
+
+For regular updates:
+```
+Update <package> to <version> (#PR)
+Bump <package> from X.Y.Z to A.B.C (#PR)
+```
+
+### Version Pinning Strategy
+
+- **Runtime deps (requirements.txt):** Pin major.minor, allow patch
+- **Dev deps (dev-requirements.txt):** Pin exact version for reproducibility
+- **Example:**
+  ```
+  requests>=2.33.0,<3.0
+  pytest==9.0.3
+  ```
+
+### Testing After Updates
+
+```bash
+# Quick validation
+./lint.sh
+mypy .
+
+# Full test (if significant update)
+sudo ./tests/test.sh
+
+# Build test (if build-related dep)
+./scripts/build_x86_64_executable.sh
+```
+
+### PR Checklist for Dependency Updates
+
+- [ ] CVE number referenced (if security fix)
+- [ ] Compatibility verified with Python 3.10+
+- [ ] Linters pass
+- [ ] Type checking passes
+- [ ] Tests pass (or document known issues)
+- [ ] No breaking API changes
+
+---
+
+## TODO: Skill Content to Add
+
+- [ ] **Add full dependency list** - Complete list with purposes
+- [ ] **Add version constraint explanations** - Why specific versions pinned
+- [ ] **Add transitive dependency notes** - Important indirect dependencies
+- [ ] **Add security advisory links** - Links to CVE databases
+- [ ] **Add test matrix for updates** - What to test for each dep type
+- [ ] **Add granulate-utils documentation** - Internal package details
+- [ ] **Add Docker base image deps** - Alpine/Ubuntu package lists
+- [ ] **Add breaking change indicators** - How to identify risky updates

--- a/.claude/skills/docker-troubleshoot/SKILL.md
+++ b/.claude/skills/docker-troubleshoot/SKILL.md
@@ -1,0 +1,105 @@
+---
+name: docker-troubleshoot
+description: Troubleshoot Docker build and container issues. Use when the user has Docker build failures, container runtime issues, or needs help with Dockerfiles.
+allowed-tools: Bash(docker *) Bash(cat *Dockerfile*) Read Grep
+---
+
+## gProfiler Docker Troubleshooting
+
+### Docker Environment
+
+```!
+docker --version 2>/dev/null || echo "Docker not found"
+docker info 2>/dev/null | grep -E "Server Version|Storage Driver|Operating System" || echo "Docker daemon not running"
+```
+
+### Key Dockerfiles
+
+| File | Purpose | Build Script |
+|------|---------|--------------|
+| `container.Dockerfile` | Full container with bundled profilers | `scripts/build_x86_64_container.sh` |
+| `executable.Dockerfile` | PyInstaller executable build | `scripts/build_x86_64_executable.sh` |
+
+### Common Build Commands
+
+```bash
+# Build container (x86_64)
+./scripts/build_x86_64_container.sh -t gprofiler:dev
+
+# Build executable
+./scripts/build_x86_64_executable.sh
+
+# Build with no cache (for debugging)
+docker build --no-cache -f container.Dockerfile -t gprofiler:test .
+
+# Build specific stage
+docker build --target builder -f container.Dockerfile -t gprofiler:builder .
+```
+
+### Troubleshooting Steps
+
+#### Build Failures
+
+1. **Check Dockerfile syntax**
+   ```bash
+   ./dockerfile_lint.sh
+   ```
+
+2. **Build with verbose output**
+   ```bash
+   docker build --progress=plain -f container.Dockerfile .
+   ```
+
+3. **Debug specific stage**
+   ```bash
+   # Build up to failing stage
+   docker build --target <stage-name> -f container.Dockerfile -t debug:stage .
+   # Inspect
+   docker run -it debug:stage /bin/bash
+   ```
+
+#### Runtime Issues
+
+```bash
+# Run with full privileges (for profiling)
+docker run --privileged -it gprofiler:dev /bin/bash
+
+# Check required capabilities
+docker run --cap-add SYS_ADMIN --cap-add SYS_PTRACE -it gprofiler:dev
+
+# Mount host for debugging
+docker run -v /tmp:/host-tmp --privileged -it gprofiler:dev
+```
+
+#### Image Size Issues
+
+```bash
+# Analyze image layers
+docker history gprofiler:dev
+
+# Check image size
+docker images gprofiler:dev
+
+# Find large files
+docker run --rm gprofiler:dev du -sh /* 2>/dev/null | sort -h
+```
+
+### Multi-Architecture Builds
+
+```bash
+# x86_64
+./scripts/build_x86_64_container.sh -t gprofiler:x86
+
+# ARM64 (requires QEMU or ARM host)
+./scripts/build_aarch64_container.sh -t gprofiler:arm64
+
+# Buildx for multi-arch (if configured)
+docker buildx build --platform linux/amd64,linux/arm64 -f container.Dockerfile .
+```
+
+### Instructions
+
+1. Identify the specific error message
+2. Determine if it's build-time or runtime
+3. Check relevant Dockerfile section
+4. Suggest minimal fix or workaround

--- a/.claude/skills/heartbeat/SKILL.md
+++ b/.claude/skills/heartbeat/SKILL.md
@@ -1,0 +1,218 @@
+---
+name: heartbeat
+description: Work with the gProfiler heartbeat system for dynamic profiling control. Use when the user asks about heartbeat mode, Performance Studio integration, or command-driven profiling.
+---
+
+## gProfiler Heartbeat System
+
+The heartbeat system enables centralized profiling control where Performance Studio can dynamically issue start/stop commands to gProfiler agents.
+
+### System Architecture
+
+```
+┌─────────────────────┐    Heartbeat     ┌──────────────────────┐
+│  Performance Studio │ ◄──────────────► │   gProfiler Agent    │
+│     Backend         │   Commands       │                      │
+└─────────────────────┘ ────────────────► └──────────────────────┘
+```
+
+### Running in Heartbeat Mode
+
+**Basic:**
+```bash
+python gprofiler/main.py \
+  --enable-heartbeat-server \
+  --upload-results \
+  --token "your-token" \
+  --service-name "web-service" \
+  --api-server "http://performance-studio:8000" \
+  --heartbeat-interval 30 \
+  --output-dir /tmp/profiles \
+  --verbose
+```
+
+**Production:**
+```bash
+export GPROFILER_TOKEN="my_token"
+export GPROFILER_SERVICE="your-service-name"
+export GPROFILER_SERVER="http://localhost:8080"
+
+/opt/gprofiler/gprofiler \
+  --enable-heartbeat-server \
+  -u \
+  --token=$GPROFILER_TOKEN \
+  --service-name=$GPROFILER_SERVICE \
+  --api-server $GPROFILER_SERVER \
+  --dont-send-logs \
+  --server-upload-timeout 10 \
+  -c \
+  --disable-metrics-collection \
+  --java-safemode= \
+  --heartbeat-interval 30 \
+  -d 60 \
+  --java-no-version-check
+```
+
+`--server-host` still exists as a deprecated alias, but prefer `--api-server`.
+
+### Required flags
+
+Current `main.py` validation requires heartbeat mode to include:
+
+- `--enable-heartbeat-server`
+- `--upload-results`
+- `--token`
+- `--service-name`
+
+Use the skill to explain or debug this mode only in terms of the current flags above.
+
+### Command Flow
+
+```
+1. User submits profiling request to backend
+   ↓
+2. Backend creates command with unique ID
+   ↓
+3. Agent sends heartbeat to backend
+   ↓
+4. Backend responds with pending command
+   ↓
+5. Agent checks idempotency (skip if already received)
+   ↓
+6. Agent enqueues command in priority queue
+   ↓
+7. Agent executes command (start/stop profiling)
+   ↓
+8. Agent reports completion to backend
+```
+
+### Command Priority Queues
+
+| Queue | Purpose | Max Size |
+|-------|---------|----------|
+| `stop_queue` | Immediate stop commands | 1 |
+| `adhoc_queue` | Single-run start commands | 10 |
+| `continuous_queue` | Long-running start commands | 1 |
+
+Priority: `stop > adhoc > continuous`
+
+The current implementation lives under `gprofiler/dynamic_profiling_management/`. Do not refer users to `gprofiler/command_control.py`; that path is stale.
+
+### API Endpoints
+
+**Submit Profiling Request:**
+```bash
+curl -X POST http://localhost:8000/api/metrics/profile_request \
+  -H "Content-Type: application/json" \
+  -d '{
+    "service_name": "web-service",
+    "command_type": "start",
+    "duration": 60,
+    "frequency": 11,
+    "profiling_mode": "cpu",
+    "target_hostnames": ["host1", "host2"]
+  }'
+```
+
+**Stop Profiling:**
+```bash
+curl -X POST http://localhost:8000/api/metrics/profile_request \
+  -H "Content-Type: application/json" \
+  -d '{
+    "service_name": "web-service",
+    "command_type": "stop",
+    "stop_level": "host",
+    "target_hostnames": ["host1"]
+  }'
+```
+
+### PerfSpect Hardware Metrics
+
+Enable Intel PerfSpect for hardware metrics:
+```bash
+curl -X POST http://localhost:8000/api/metrics/profile_request \
+  -H "Content-Type: application/json" \
+  -d '{
+    "service_name": "web-service",
+    "command_type": "start",
+    "duration": 60,
+    "additional_args": {
+      "enable_perfspect": true
+    }
+  }'
+```
+
+Requirements:
+- Linux x86_64 (Intel architecture)
+- Root access
+- Internet for auto-install
+
+### Key Files
+
+```
+gprofiler/main.py                                       # CLI + heartbeat flag validation
+gprofiler/dynamic_profiling_management/heartbeat.py     # Polling and command handling
+gprofiler/dynamic_profiling_management/command_control.py # Queue logic and priority
+gprofiler/dynamic_profiling_management/continuous.py    # Continuous slot
+gprofiler/dynamic_profiling_management/ad_hoc.py        # Ad-hoc slot
+tests/test_heartbeat_system.py                          # Heartbeat flow validation
+docs/HEARTBEAT_SYSTEM_README.md                         # Full documentation
+```
+
+### Testing heartbeat changes
+
+Use the smallest useful validation first:
+
+```bash
+# Focused heartbeat test
+sudo python3 -m pytest -v tests/test_heartbeat_system.py
+
+# Lightweight broader regression
+sudo ./tests/test.sh --executable
+```
+
+For local end-to-end testing against a backend, the repo docs describe this sequence:
+
+1. Start the Performance Studio backend.
+2. Run `python tests/run_heartbeat_agent.py`
+3. Submit commands with `python tests/test_heartbeat_system.py --live`
+
+Prefer the existing docs/test scripts over inventing custom heartbeat harnesses.
+
+### Troubleshooting
+
+**Agent not receiving commands:**
+- Check network connectivity
+- Verify authentication token
+- Check service name matching
+
+**Commands not executing:**
+- Check agent logs for errors
+- Verify command parameters
+- Check system permissions
+
+**PerfSpect not working:**
+- Verify Linux x86_64 platform
+- Check root permissions
+- Check `/tmp/gprofiler_perfspect/perfspect/`
+
+### CLI Options Reference
+
+```bash
+--enable-heartbeat-server     # Enable heartbeat mode
+--heartbeat-interval 30       # Heartbeat frequency (seconds)
+--api-server URL              # Backend server URL
+--server-host URL             # Deprecated alias for --api-server
+--upload-results              # Required for heartbeat mode
+--token TOKEN                 # Authentication token
+--service-name NAME           # Service identifier
+--enable-hw-metrics-collection # Enable PerfSpect
+--perfspect-path PATH         # PerfSpect binary path
+```
+
+### Review points for heartbeat work
+
+- Preserve queue semantics: `stop > adhoc > continuous`
+- Preserve idempotency; do not allow the same command to execute twice
+- Avoid moving heartbeat logic into `main.py` if `dynamic_profiling_management/` is sufficient
+- Add targeted heartbeat tests before broader regression runs

--- a/.claude/skills/implement-from-spec/SKILL.md
+++ b/.claude/skills/implement-from-spec/SKILL.md
@@ -1,0 +1,155 @@
+---
+name: implement-from-spec
+description: Implement gProfiler changes from a design spec. Use when the user asks to build a feature, modify behavior, or turn an architecture/design proposal into code with local setup, targeted unit/e2e tests, and regression-aware review.
+context: fork
+user-invocable: true
+---
+
+## Implementing gProfiler Changes From a Design Spec
+
+Use this skill when the task is not just "edit code", but "map a spec onto the current gProfiler architecture, implement it with the smallest safe change, and prove it locally."
+
+## Workflow
+
+1. Read the design spec and classify the change before editing code.
+2. Map the request onto the current architecture and choose the smallest existing flow that already solves most of the problem.
+3. Prefer extending an existing path over inventing a parallel one.
+4. Make focused edits first, then run the smallest test set that exercises the changed path.
+5. Expand to broader regression coverage only after targeted tests pass.
+6. Do an architecture-aware review before handing off.
+
+## Architecture map
+
+| Area | Primary files | Notes |
+|------|---------------|-------|
+| CLI + orchestration | `gprofiler/main.py` (~1546 lines) | Entry point, wiring, runtime args. High-risk hotspot; avoid broad rewrites. |
+| Dynamic profiling command control | `gprofiler/dynamic_profiling_management/command_control.py` (~233), `heartbeat.py` (~354), `continuous.py` (~68), `ad_hoc.py` (~76) | Best place for heartbeat polling, queueing, start/stop handling, pause/resume semantics. |
+| Runtime profilers | `gprofiler/profilers/*.py` | Extend the profiler-specific module before touching orchestration. Large hotspots include `java.py` (~1555) and `perf.py` (~441). |
+| Merge/output | `gprofiler/merge.py` (~330) | Use for stack merging and output shaping, not profiler lifecycle changes. |
+| Test harness | `tests/conftest.py` (~708), `tests/test_heartbeat_system.py` (~362), targeted `tests/test_*.py` | `conftest.py` is shared infra and regression-sensitive. Change it only when the spec truly needs new shared fixtures/behaviors. |
+
+## Choose the right existing flow
+
+### If the spec changes command-driven profiling
+
+Prefer this flow:
+
+1. Heartbeat poll / response handling in `gprofiler/dynamic_profiling_management/heartbeat.py`
+2. Queueing / priority rules in `gprofiler/dynamic_profiling_management/command_control.py`
+3. Execution routing in `continuous.py` or `ad_hoc.py`
+4. Completion / status propagation back through the heartbeat path
+5. Tests in `tests/test_heartbeat_system.py` plus any targeted profiler tests
+
+Do **not** add a second control path if the existing heartbeat + `CommandManager` path can be extended.
+
+### If the spec changes sampling or profiler behavior
+
+Prefer:
+
+1. Update the specific profiler in `gprofiler/profilers/`
+2. Keep lifecycle behavior compatible with `ProfilerBase`
+3. Only touch `main.py` if the change needs new CLI wiring or orchestration
+4. Add/adjust profiler-specific tests before broad test-suite runs
+
+### If the spec changes stack merging, metadata, or output
+
+Prefer:
+
+1. `gprofiler/merge.py` for aggregation/output semantics
+2. `gprofiler/metadata/` for metadata enrichment
+3. README/help text only if the change is user-visible
+
+## Command-control example
+
+For a design such as "add new targeting metadata to heartbeat and make command dispatch use it":
+
+1. Start with `docs/HEARTBEAT_SYSTEM_README.md` to understand the current protocol.
+2. Check `heartbeat.py` for payload creation/parsing.
+3. Check `command_control.py` for queue semantics:
+   - stop commands stay highest priority
+   - ad-hoc commands outrank continuous commands
+   - continuous commands may be paused/resumed
+4. Keep idempotency intact. Do not create a path that can enqueue or execute the same command twice.
+5. Validate with `tests/test_heartbeat_system.py` and then broader tests if shared behavior changed.
+
+## Local setup and test bootstrap
+
+Prefer the repo's existing test harness over ad-hoc local setup. It already knows how to install dependencies and spin up runtime resources.
+
+### First-time setup
+
+```bash
+git submodule update --init
+python3 -m pip install -r requirements.txt -r dev-requirements.txt
+sudo python3 -m pip install -r requirements.txt -r dev-requirements.txt
+./scripts/copy_resources_from_image.sh
+```
+
+### Fastest way to bootstrap the test stack
+
+```bash
+sudo ./tests/test.sh --executable
+```
+
+Use this first when you need a quick sanity check without the full container/resource-heavy suite.
+
+### Full local validation
+
+```bash
+sudo ./tests/test.sh
+```
+
+Notes:
+
+- `tests/test.sh` can auto-install missing apt packages and Docker dependencies unless `NO_APT_INSTALL` is set.
+- The pytest infrastructure and `tests/conftest.py` spin up the needed runtime containers/resources for many tests. Prefer that over writing one-off setup scripts.
+- If `gprofiler/resources/perf` is missing, extract resources first rather than patching tests around it.
+
+## Test selection matrix
+
+Run the narrowest useful test first, then widen.
+
+| Change type | First tests | Then |
+|-------------|-------------|------|
+| Dynamic profiling / heartbeat / queue behavior | `sudo python3 -m pytest -v tests/test_heartbeat_system.py` | `sudo ./tests/test.sh --executable`, then `sudo ./tests/test.sh` if shared behavior changed |
+| Specific profiler behavior | Target that file, for example `sudo python3 -m pytest -v tests/test_perf.py` or `tests/test_java.py` | Full suite if lifecycle/shared fixtures changed |
+| Merge/output/metadata | Targeted `tests/test_merge.py`, `tests/test_app_metadata.py`, `tests/test_appids.py` | `sudo ./tests/test.sh --executable` or full suite depending on scope |
+| Shared fixtures / `main.py` / cross-cutting changes | Start with the most relevant targeted tests | Always finish with `sudo ./tests/test.sh` before handoff |
+
+For debugging:
+
+```bash
+cd tests && sudo python3 -m pytest -v -s --tb=long -k "test_name"
+docker ps -a
+```
+
+## Regression-aware implementation rules
+
+- Extend the current flow before adding a new abstraction.
+- Keep behavior compatible with existing queue priority and cancellation semantics.
+- Preserve cleanup paths for spawned profilers/processes.
+- Respect root-only / privileged behavior in tests and runtime code.
+- Avoid changing `tests/conftest.py` unless multiple tests truly need the new fixture or environment behavior.
+- If you touch a large hotspot file, explain why a smaller module was not sufficient.
+
+## Architecture-aware review checklist
+
+- [ ] The spec was mapped to an existing flow before code was added.
+- [ ] No duplicate control path was introduced for heartbeat/command handling.
+- [ ] `CommandManager` priority still behaves as `stop > adhoc > continuous`.
+- [ ] Idempotency and completion reporting still make sense.
+- [ ] New code uses the smallest reasonable seam instead of broad rewrites in `main.py`, `java.py`, or `conftest.py`.
+- [ ] User-visible changes update docs/help text if needed.
+- [ ] Targeted tests were run first, and broader regression coverage was added when the change touched shared code.
+- [ ] The final test plan clearly separates unit-ish targeted tests from heavier end-to-end validation.
+
+## When to stop and rethink
+
+Stop and revisit the plan if:
+
+- the design spec seems to require a new control path even though heartbeat/queueing already covers it
+- the change starts spreading across `main.py`, multiple profilers, and `conftest.py` at once
+- the only way to make progress is to skip the repo's existing test harness
+- targeted tests cannot be identified from the changed architecture area
+
+In those cases, narrow the design, split the change, or document why a larger refactor is unavoidable.

--- a/.claude/skills/java-support/SKILL.md
+++ b/.claude/skills/java-support/SKILL.md
@@ -1,0 +1,139 @@
+---
+name: java-support
+description: Add or update Java JDK version support. Use when the user needs to add support for a new JDK version or fix Java profiling issues.
+user-invocable: true
+---
+
+## Adding Java JDK Version Support
+
+**Context from history:** Java support is the most frequently updated profiler (17 commits in 3 years). New JDK releases require quick gProfiler updates.
+
+### Supported JDK Versions
+
+Currently supported: JDK 7+ (HotSpot-based JVMs)
+- Oracle JDK
+- OpenJDK (AdoptOpenJDK, Azul Zulu, Temurin, etc.)
+
+Recent additions (from commit history):
+- JDK 17, 18, 19, 21, 25
+- Temurin JDK support
+
+### Key Files to Modify
+
+```
+gprofiler/profilers/java.py           # Main Java profiler (67KB, 19 changes)
+tests/test_java.py                    # Java tests (51KB, 11 changes)
+gprofiler/resources/                  # async-profiler binaries
+```
+
+### Adding New JDK Version Support
+
+**Step 1: Update Version Detection**
+
+In `gprofiler/profilers/java.py`, find the JDK version detection logic:
+```python
+# Look for patterns like:
+MIN_JDK_VERSION = ...
+SUPPORTED_JDK_VERSIONS = [...]
+```
+
+**Step 2: Update async-profiler Compatibility**
+
+Check if async-profiler supports the new JDK:
+- async-profiler v3.0 added in recent updates
+- DSO storage directory issues fixed for newer JDKs
+
+**Step 3: Add Tests**
+
+In `tests/test_java.py`:
+```python
+@pytest.mark.parametrize("jdk_version", [..., "new_version"])
+def test_java_profiling_jdk_versions(jdk_version):
+    ...
+```
+
+**Step 4: Update Test Docker Images**
+
+From history: `openjdk:11-jdk` deprecated → moved to Temurin
+```python
+# In conftest.py or test_java.py
+JAVA_TEST_IMAGES = {
+    "8": "eclipse-temurin:8-jdk",
+    "11": "eclipse-temurin:11-jdk",
+    "17": "eclipse-temurin:17-jdk",
+    "21": "eclipse-temurin:21-jdk",
+    # Add new version
+}
+```
+
+### Common Issues from History
+
+**1. Directory Ownership for AsyncProfiler DSO**
+```
+# Commit: Support java profiling without root privilege (#987)
+# Issue: DSO storage directory permissions
+```
+
+**2. Version Detection from Process Names**
+```
+# Some JDKs report version differently
+# Check /proc/<pid>/cmdline parsing
+```
+
+**3. Rootless Container Profiling**
+```
+# Commit: Support java profiling without root privilege in a container (#987)
+# Solution: Check process namespace and permissions
+```
+
+### Testing New JDK Support
+
+```bash
+# Test specific JDK version
+cd tests && sudo python3 -m pytest -v test_java.py -k "jdk21"
+
+# Test latest JVMs sanity
+cd tests && sudo python3 -m pytest -v -k "test_sanity_latest_jvms"
+
+# Full Java test suite
+cd tests && sudo python3 -m pytest -v test_java.py
+```
+
+### Commit Message Pattern
+
+From history, Java commits follow this pattern:
+```
+java: Add JDK <version> support (#PR_NUMBER)
+java: Update min JDK <version> version (#PR_NUMBER)
+java: Fix <issue> for JDK <version> (#PR_NUMBER)
+```
+
+### Java Profiling Options (from README)
+
+```bash
+# Disable Java profiling
+--no-java
+--java-mode disabled
+
+# Disable buildid embedding
+--no-java-async-profiler-buildids
+
+# Skip version check (for testing)
+--java-no-version-check
+
+# Safe mode (empty to disable)
+--java-safemode=
+```
+
+---
+
+## TODO: Skill Content to Add
+
+- [ ] **Add JDK version detection code** - Actual code snippets from java.py
+- [ ] **Add async-profiler flags reference** - All async-profiler options used
+- [ ] **Add JVM vendor compatibility matrix** - Oracle, Temurin, Azul, etc.
+- [ ] **Add allocation profiling guide** - How to enable allocation profiling
+- [ ] **Add JFR comparison** - When to use async-profiler vs JFR
+- [ ] **Add container Java detection** - How Java processes are found in containers
+- [ ] **Add frame format examples** - Example Java stack frames
+- [ ] **Add troubleshooting decision tree** - Flowchart for Java profiling issues

--- a/.claude/skills/lint/SKILL.md
+++ b/.claude/skills/lint/SKILL.md
@@ -1,0 +1,108 @@
+---
+name: lint
+description: Run all code quality checks and auto-fix formatting issues. Use when the user wants to lint, format, or check code style before committing.
+allowed-tools: Bash(isort *) Bash(black *) Bash(flake8 *) Bash(mypy *) Bash(./lint.sh *) Bash(./shell_lint.sh) Bash(./dockerfile_lint.sh) Bash(pip *) Bash(bandit *)
+---
+
+## gProfiler Code Quality Tools
+
+**Project standards:** Line length 120, Python 3.10+, strict mypy
+
+### Quick Commands
+
+```bash
+# Run all Python linters with auto-fix
+./lint.sh
+
+# CI mode (check only, no auto-formatting)
+./lint.sh --ci
+
+# Shell script linting (uses Docker)
+./shell_lint.sh
+
+# Dockerfile linting (uses Docker)
+./dockerfile_lint.sh
+```
+
+### Individual Tools
+
+| Tool | Command | Purpose |
+|------|---------|---------|
+| **isort** | `isort --settings-path .isort.cfg .` | Import sorting (line_length: 120) |
+| **black** | `black --line-length 120 .` | Code formatting |
+| **flake8** | `flake8 --config .flake8 .` | Style linting |
+| **mypy** | `mypy .` | Type checking (strict mode) |
+| **shellcheck** | `./shell_lint.sh` | Shell script linting |
+| **hadolint** | `./dockerfile_lint.sh` | Dockerfile linting |
+
+### Configuration Files
+
+- `.isort.cfg` - Import sorting config (line_length=120, multi_line_output=3)
+- `.flake8` - Flake8 config (max_line_length=120)
+- `mypy.ini` - Type checking (strict mode, no_implicit_optional=False)
+
+### Common Issues from History
+
+**1. Import Order (isort)**
+```python
+# Correct format (3-line grouped with trailing comma)
+import logging
+import os
+from pathlib import Path
+
+from granulate_utils import ...
+from psutil import ...
+
+from gprofiler.utils import ...
+```
+
+**2. Line Length (120 chars)**
+- Use parentheses for line continuation
+- Break long strings with implicit concatenation
+
+**3. Type Hints (mypy)**
+- All public functions need type hints
+- Use `Optional[T]` for nullable parameters
+- Use `from __future__ import annotations` for forward refs
+
+**4. Black Formatting**
+- CVE-2024 issue with black package fixed in recent versions
+- Ensure dev-requirements.txt has latest black
+
+### Pre-Commit Checklist
+
+1. `./lint.sh` - Auto-fix formatting
+2. `mypy .` - Check types
+3. `./shell_lint.sh` - If shell scripts modified
+4. `./dockerfile_lint.sh` - If Dockerfiles modified
+
+### CI Workflow
+
+The `.github/workflows/linters.yml` runs:
+1. Python linters (isort, black, flake8)
+2. mypy type checking
+3. shellcheck via Docker
+4. hadolint via Docker
+
+### Bandit Security Linting
+
+For security-sensitive changes:
+```bash
+pip install bandit
+bandit -r gprofiler/
+```
+
+Note: B404 (subprocess import) is a known finding - use subprocess safely.
+
+---
+
+## TODO: Skill Content to Add
+
+- [ ] **Add example error messages** - Common linting errors and how to fix them
+- [ ] **Add IDE integration section** - VS Code, PyCharm settings for auto-formatting
+- [ ] **Add mypy error explanations** - Common mypy errors specific to gProfiler patterns
+- [ ] **Add flake8 ignore patterns** - Document which rules are ignored and why
+- [ ] **Add shell lint examples** - Common shellcheck warnings in build scripts
+- [ ] **Add Dockerfile lint examples** - hadolint warnings and fixes
+- [ ] **Add CI failure troubleshooting** - How to debug linting failures in CI
+- [ ] **Add git hooks setup** - Optional pre-commit hook configuration

--- a/.claude/skills/new-profiler/SKILL.md
+++ b/.claude/skills/new-profiler/SKILL.md
@@ -1,0 +1,261 @@
+---
+name: new-profiler
+description: Guide for adding a new profiler to gProfiler. Use when the user wants to add support for a new language runtime or profiling tool.
+user-invocable: true
+disable-model-invocation: true
+---
+
+## Adding a New Profiler to gProfiler
+
+### Architecture Overview
+
+```
+gprofiler/profilers/
+├── profiler_base.py      # Base class - extend this
+├── registry.py           # @register_profiler decorator
+├── factory.py            # Profiler instantiation
+├── perf.py               # System profiler (reference: 19KB)
+├── java.py               # Java profiler (reference: 67KB)
+├── python.py             # Python py-spy profiler
+├── python_ebpf.py        # Python PyPerf profiler
+├── ruby.py               # Ruby rbspy profiler
+├── php.py                # PHP phpspy profiler
+├── dotnet.py             # .NET dotnet-trace profiler
+└── node.py               # NodeJS profiler
+```
+
+### Step 1: Create Profiler Class
+
+Create `gprofiler/profilers/<runtime>.py`:
+
+```python
+#
+# Copyright (C) 2022 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+import logging
+from typing import Optional
+
+from gprofiler.gprofiler_types import ProcessToProfileData, ProfileData
+from gprofiler.log import get_logger_adapter
+from gprofiler.profilers.profiler_base import ProfilerBase
+from gprofiler.profilers.registry import register_profiler
+
+logger = get_logger_adapter(__name__)
+
+
+@register_profiler(
+    "MyRuntime",
+    # Possible profiler names for CLI selection
+    possible_modes=["myruntime", "disabled"],
+    # Default mode
+    default_mode="myruntime",
+    # Supported architectures
+    supported_archs=["x86_64", "aarch64"],
+    # Profiler-specific CLI arguments
+    profiler_arguments=[
+        # Add any runtime-specific arguments
+    ],
+)
+class MyRuntimeProfiler(ProfilerBase):
+    """
+    Profiler for MyRuntime applications.
+    """
+
+    # Frame suffix for this profiler (shown in flamegraph)
+    FRAME_SUFFIX = "_[myrt]"
+
+    def __init__(
+        self,
+        frequency: int,
+        duration: int,
+        stop_event,
+        storage_dir: str,
+        profile_spawned_processes: bool,
+        *args,
+        **kwargs,
+    ):
+        super().__init__(
+            frequency=frequency,
+            duration=duration,
+            stop_event=stop_event,
+            storage_dir=storage_dir,
+            profile_spawned_processes=profile_spawned_processes,
+        )
+        # Initialize profiler-specific state
+
+    def start(self) -> None:
+        """Start the profiler. Called once at the beginning."""
+        logger.info("Starting MyRuntime profiler")
+        # Initialize profiling tools, attach to processes, etc.
+
+    def stop(self) -> None:
+        """Stop the profiler. Called once at the end."""
+        logger.info("Stopping MyRuntime profiler")
+        # Cleanup resources, detach from processes
+
+    def snapshot(self) -> ProcessToProfileData:
+        """
+        Collect profiling data for one interval.
+        Called periodically during profiling.
+
+        Returns:
+            Dict mapping process info to ProfileData
+        """
+        results: ProcessToProfileData = {}
+
+        # Collect samples from your profiling tool
+        # Parse stack traces
+        # Build ProfileData for each process
+
+        return results
+```
+
+### Step 2: Add CLI Arguments
+
+In `gprofiler/main.py`, add runtime-specific arguments:
+
+```python
+# In the argument parser section
+parser.add_argument(
+    "--myruntime-mode",
+    choices=["myruntime", "disabled"],
+    default="myruntime",
+    help="MyRuntime profiling mode",
+)
+parser.add_argument(
+    "--no-myruntime",
+    action="store_true",
+    help="Disable MyRuntime profiling",
+)
+```
+
+### Step 3: Add Tests
+
+Create `tests/test_myruntime.py`:
+
+```python
+import pytest
+from tests.conftest import AssertInCollapsed
+
+class TestMyRuntimeProfiler:
+    @pytest.mark.parametrize("version", ["1.0", "2.0"])
+    def test_myruntime_profiling(
+        self,
+        application_docker_container,
+        runtime_specific_args,
+        assert_collapsed: AssertInCollapsed,
+    ):
+        """Test profiling of MyRuntime applications."""
+        # Test implementation
+        pass
+```
+
+### Step 4: Add Resources (if needed)
+
+If your profiler requires external tools:
+
+```
+gprofiler/resources/
+└── myruntime/
+    ├── x86_64/
+    │   └── profiler_tool
+    └── aarch64/
+        └── profiler_tool
+```
+
+Update build scripts in `scripts/` to include the tool.
+
+### Step 5: Update Documentation
+
+1. Update `README.md` with:
+   - Runtime support in architecture table
+   - Profiling options section
+   - Frame format documentation
+
+2. Add to frame suffix table:
+   ```
+   | MyRuntime | Per tool | `_[myrt]` |
+   ```
+
+### Key Patterns from Existing Profilers
+
+**Process Discovery:**
+```python
+from gprofiler.utils.process import search_for_process
+
+processes = search_for_process(
+    lambda p: "myruntime" in p.cmdline(),
+    self._stop_event,
+)
+```
+
+**Resource Cleanup:**
+```python
+def stop(self) -> None:
+    try:
+        # Cleanup
+    except Exception:
+        logger.exception("Error stopping profiler")
+    finally:
+        # Ensure resources released
+```
+
+**Handling Stop Event:**
+```python
+def snapshot(self) -> ProcessToProfileData:
+    if self._stop_event.is_set():
+        return {}
+    # Continue profiling...
+```
+
+### Testing Your Profiler
+
+```bash
+# Run profiler tests
+cd tests && sudo python3 -m pytest -v test_myruntime.py
+
+# Test with verbose output
+sudo python3 -m gprofiler --myruntime-mode=myruntime -v -d 30 -o /tmp/output
+
+# Verify frame format in output
+cat /tmp/output/last_profile.col | grep "_[myrt]"
+```
+
+### Commit Message Pattern
+
+```
+Add <Runtime> profiler support (#PR_NUMBER)
+<runtime>: Add version X.Y support (#PR_NUMBER)
+```
+
+---
+
+## TODO: Skill Content to Add
+
+- [ ] **Add complete profiler lifecycle diagram** - Visual flow of start/snapshot/stop
+- [ ] **Add ProfilerBase method documentation** - All methods with signatures
+- [ ] **Add example profiler implementations** - Annotated code from simple profilers
+- [ ] **Add process discovery patterns** - Different ways to find target processes
+- [ ] **Add stack trace parsing examples** - How to parse different profiler outputs
+- [ ] **Add resource bundling guide** - How to add external binaries to build
+- [ ] **Add profiler configuration patterns** - How CLI args flow to profiler
+- [ ] **Add frame format specification** - Detailed frame suffix requirements
+
+### Candidate New Profilers to Document
+
+- [ ] **Rust** - Native profiling with symbolication
+- [ ] **Erlang/BEAM** - Erlang VM profiling
+- [ ] **Lua/LuaJIT** - Lua runtime profiling

--- a/.claude/skills/pr-create/SKILL.md
+++ b/.claude/skills/pr-create/SKILL.md
@@ -1,0 +1,73 @@
+---
+name: pr-create
+description: Create a well-formatted pull request for gProfiler. Use when the user wants to submit changes, create a PR, or push their work.
+disable-model-invocation: true
+allowed-tools: Bash(git *) Bash(gh *)
+---
+
+## Create gProfiler Pull Request
+
+### Current Branch Status
+
+```!
+echo "Branch: $(git branch --show-current)"
+echo "Base: master"
+echo ""
+echo "Commits to include:"
+git log master..HEAD --oneline 2>/dev/null || echo "No commits ahead of master"
+echo ""
+echo "Files changed:"
+git diff --stat master..HEAD 2>/dev/null || git diff --stat HEAD
+```
+
+### PR Checklist
+
+Before creating PR, verify:
+- [ ] Code formatted: `./lint.sh` passes
+- [ ] Type hints: `mypy .` passes
+- [ ] Tests pass locally (if applicable)
+- [ ] Commit messages are descriptive
+- [ ] No secrets or credentials in diff
+
+### PR Template
+
+**Title format:** `<type>: <short description>`
+- Types: `feat`, `fix`, `docs`, `refactor`, `test`, `build`, `ci`
+
+**Body sections:**
+```markdown
+## Summary
+Brief description of what this PR does.
+
+## Changes
+- Bullet points of specific changes
+
+## Testing
+How the changes were tested.
+
+## Related Issues
+Fixes #123 (if applicable)
+```
+
+### Instructions
+
+1. Review the commits and changes above
+2. Generate appropriate PR title and description
+3. Run: `gh pr create --title "..." --body "..."`
+4. If tests need to run: `gh pr checks --watch`
+
+### Example Commands
+
+```bash
+# Create PR with editor
+gh pr create
+
+# Create PR inline
+gh pr create --title "fix: handle missing perf binary gracefully" --body "..."
+
+# Create draft PR
+gh pr create --draft --title "wip: add Go profiler support"
+
+# Push and create PR
+git push -u origin $(git branch --show-current) && gh pr create
+```

--- a/.claude/skills/review-code/SKILL.md
+++ b/.claude/skills/review-code/SKILL.md
@@ -1,0 +1,89 @@
+---
+name: review-code
+description: Review code changes against gProfiler coding standards. Use when the user asks to review code, check a PR, or validate changes before committing.
+---
+
+## gProfiler Code Review Checklist
+
+### Current Changes
+
+!`git diff --stat HEAD 2>/dev/null || echo "No git changes"`
+
+### Hotspots to review carefully
+
+Large shared files deserve extra skepticism because regressions spread quickly:
+
+| File | Approx. lines | Review concern |
+|------|---------------|----------------|
+| `gprofiler/main.py` | ~1546 | Broad orchestration / CLI changes can affect many runtimes |
+| `gprofiler/profilers/java.py` | ~1555 | Complex runtime-specific behavior |
+| `tests/conftest.py` | ~708 | Shared fixtures; small changes can break many tests |
+| `gprofiler/dynamic_profiling_management/heartbeat.py` | ~354 | Command-control behavior and backend contract |
+| `gprofiler/dynamic_profiling_management/command_control.py` | ~233 | Queue semantics and execution ordering |
+
+Ask whether the change could have been made in a smaller seam before accepting edits to these files.
+
+### Coding Standards
+
+#### Python Style
+- [ ] Line length ≤ 120 characters
+- [ ] Type hints on all public functions
+- [ ] Apache 2.0 license header on new files
+- [ ] Imports sorted (stdlib → external → local) with trailing comma
+- [ ] Uses `get_logger_adapter(__name__)` for logging
+
+#### Security
+- [ ] No hardcoded credentials or secrets
+- [ ] Input validation on external data
+- [ ] Safe subprocess usage (no shell=True with user input)
+- [ ] Proper error handling for privileged operations
+
+#### Profiler-Specific
+- [ ] Handles process termination gracefully
+- [ ] Cleans up resources in `stop()` method
+- [ ] Respects `stop_event` for cancellation
+- [ ] Handles missing/unavailable profiler tools
+
+#### Architecture-Aware Checks
+- [ ] The change extends an existing flow instead of creating a parallel one
+- [ ] Dynamic profiling work stays in `gprofiler/dynamic_profiling_management/` unless `main.py` wiring is truly required
+- [ ] `CommandManager` behavior still preserves `stop > adhoc > continuous`
+- [ ] Idempotency / completion semantics still make sense for command-driven changes
+- [ ] Shared fixtures in `tests/conftest.py` changed only if multiple tests truly need new shared infra
+- [ ] User-visible CLI or runtime behavior stays backward-compatible unless the change explicitly intends a break
+
+#### Testing
+- [ ] Tests added for new functionality
+- [ ] The smallest relevant targeted tests were run first
+- [ ] Root privileges and runtime requirements were considered
+- [ ] Broader regression coverage was added when shared code changed
+- [ ] Docker fixtures / existing test harness were used instead of ad-hoc setup
+
+#### Documentation
+- [ ] README updated for user-facing changes
+- [ ] Docstrings on complex functions
+- [ ] CLI help text for new arguments
+
+### Review Instructions
+
+1. Check the diff above for violations
+2. Run `./lint.sh --ci` to verify formatting
+3. Verify type hints with `mypy .`
+4. Look for common issues:
+   - Missing error handling in profiler code
+   - Unclosed file handles or processes
+   - Missing cleanup in exception paths
+   - Hardcoded paths that should be configurable
+5. If command-control files changed, explicitly review:
+   - queue priority
+   - pause/resume behavior
+   - duplicate-command protection
+   - completion / failure reporting
+6. If `main.py` or `tests/conftest.py` changed, ask whether a smaller module could have absorbed the change
+
+### Common regression traps
+
+- Putting runtime-specific logic into `main.py` instead of the relevant profiler or dynamic-profiling module
+- Introducing a second control path instead of extending heartbeat + queue handling
+- Editing shared fixtures for a single test case
+- Adding heavyweight full-suite expectations when a narrower targeted test would have validated the change first

--- a/.claude/skills/test/SKILL.md
+++ b/.claude/skills/test/SKILL.md
@@ -1,0 +1,180 @@
+---
+name: test
+description: Run gProfiler test suite. Use when the user wants to run tests, check if tests pass, or test specific functionality.
+allowed-tools: Bash(sudo *) Bash(pytest *) Bash(python3 -m pytest *) Bash(./tests/test.sh *) Bash(cd *) Read
+---
+
+## gProfiler Test Suite
+
+**Important:** Tests require root privileges (sudo) for profiling system resources.
+
+### First-time local setup
+
+```bash
+git submodule update --init
+python3 -m pip install -r requirements.txt -r dev-requirements.txt
+sudo python3 -m pip install -r requirements.txt -r dev-requirements.txt
+./scripts/copy_resources_from_image.sh
+```
+
+Prefer the repo's existing harness over custom setup scripts. `tests/test.sh` already installs missing apt packages unless `NO_APT_INSTALL` is set, checks required resources, and runs pytest with the expected environment.
+
+### Quick Commands
+
+```bash
+# Full test suite
+sudo ./tests/test.sh
+
+# Executable-only tests (no Docker resources needed)
+sudo ./tests/test.sh --executable
+
+# Specific test file
+cd tests && sudo python3 -m pytest -v test_perf.py
+
+# Specific test by name
+cd tests && sudo python3 -m pytest -v -k "test_java_profiling"
+
+# Run with verbose output
+cd tests && sudo python3 -m pytest -v -s test_sanity.py
+```
+
+### Staged test strategy
+
+Run the narrowest useful tests first, then widen:
+
+| Change type | First tests | Then |
+|-------------|-------------|------|
+| Heartbeat / dynamic profiling / queue logic | `sudo python3 -m pytest -v tests/test_heartbeat_system.py` | `sudo ./tests/test.sh --executable`, then `sudo ./tests/test.sh` if shared code changed |
+| Specific profiler | Target that profiler's test file | `sudo ./tests/test.sh --executable` or full suite if lifecycle/shared infra changed |
+| Merge / metadata / output | `tests/test_merge.py`, `tests/test_app_metadata.py`, `tests/test_appids.py` | Broader regression depending on touched files |
+| `main.py`, `tests/conftest.py`, or cross-cutting changes | Most relevant targeted tests first | Always end with `sudo ./tests/test.sh` |
+
+This staged approach reduces regression risk without paying full-suite cost for every small change.
+
+### Test Categories
+
+| Test File | Purpose | Notes |
+|-----------|---------|-------|
+| `test_sanity.py` | Basic smoke tests | Quick validation |
+| `test_java.py` | Java profiler tests | Tests JDK 8-25, largest file (51KB) |
+| `test_python.py` | Python profiler tests | py-spy and PyPerf |
+| `test_perf.py` | System profiler tests | perf integration |
+| `test_merge.py` | Profile merging | Data aggregation |
+| `test_appids.py` | App identification | Metadata extraction |
+| `test_executable.py` | Binary mode tests | PyInstaller build |
+| `test_app_metadata.py` | Metadata collection | Frequently modified |
+
+### Known Flaky Tests (from 3-year history)
+
+**PyPerf/Python eBPF tests:**
+- TMPDIR setup issues
+- Non-blocking I/O problems
+- Solution: Tests use `@pytest.mark.flaky(reruns=3, reruns_delay=2)`
+
+**Java tests:**
+- JDK version compatibility
+- AsyncProfiler DSO directory permissions
+- Temurin vs OpenJDK differences
+
+**Dotnet tests:**
+- patchelf installation required
+- Timeout increases needed for newer .NET SDK
+
+### Test Infrastructure
+
+**conftest.py fixtures (most modified file - 13 changes in 3 years):**
+- Docker container management
+- Test application builders
+- Resource cleanup
+- Architecture detection (x86_64/aarch64)
+
+**pytest plugins:**
+- `pytest-rerunfailures` - Retry flaky tests
+- `pytest-timeout` - Prevent hanging tests
+
+Treat `tests/conftest.py` as shared infrastructure. Only change it when multiple tests need new common behavior.
+
+### Running Tests for Specific Profilers
+
+```bash
+# Java profiler
+cd tests && sudo python3 -m pytest -v test_java.py
+
+# Python profiler (py-spy)
+cd tests && sudo python3 -m pytest -v test_python.py -k "pyspy"
+
+# Python profiler (PyPerf/eBPF)
+cd tests && sudo python3 -m pytest -v test_python.py -k "pyperf"
+
+# System profiler (perf)
+cd tests && sudo python3 -m pytest -v test_perf.py
+
+# Sanity tests with latest JVMs
+cd tests && sudo python3 -m pytest -v -k "test_sanity_latest_jvms"
+```
+
+### ARM/Aarch64 Testing
+
+From history: ARM tests have recurring issues
+- `in_container` fixture for container tests
+- Platform-specific test skips
+- getaddrinfo() EBUSY errors on ARM
+
+```bash
+# Check architecture
+uname -m
+
+# Run with architecture awareness
+cd tests && sudo python3 -m pytest -v --ignore=test_bigdata.py
+```
+
+### Test Environment Setup
+
+For most contributors, the setup above plus `sudo ./tests/test.sh --executable` is the fastest way to prove the local test stack is healthy.
+
+### Heartbeat / local e2e testing
+
+For command-driven profiling changes:
+
+```bash
+# Focused heartbeat validation
+sudo python3 -m pytest -v tests/test_heartbeat_system.py
+```
+
+For a live backend flow, the heartbeat docs describe:
+
+1. Start Performance Studio backend
+2. Run `python tests/run_heartbeat_agent.py`
+3. Submit commands with `python tests/test_heartbeat_system.py --live`
+
+Use the existing scripts above instead of writing a one-off harness.
+
+### Debugging Test Failures
+
+```bash
+# Run with full output
+cd tests && sudo python3 -m pytest -v -s --tb=long test_name.py
+
+# Run specific test with debugging
+cd tests && sudo python3 -m pytest -v -s -k "test_specific_name" --pdb
+
+# Check Docker containers
+docker ps -a | grep gprofiler
+docker logs <container_id>
+```
+
+### CI Test Workflow
+
+`.github/workflows/build-test-deploy.yml`:
+1. Build executable (x86_64, aarch64)
+2. Run executable tests
+3. Build container with profilers
+4. Run container tests
+5. Deploy on tag push
+
+### Validation checklist
+
+- [ ] Choose targeted tests based on the changed architecture area
+- [ ] Use `sudo ./tests/test.sh --executable` as the default broader sanity pass
+- [ ] Run full `sudo ./tests/test.sh` after shared-fixture or cross-cutting changes
+- [ ] Reuse existing test harness/scripts instead of ad-hoc local setup

--- a/.claude/skills/version-release/SKILL.md
+++ b/.claude/skills/version-release/SKILL.md
@@ -1,0 +1,127 @@
+---
+name: version-release
+description: Release a new version of gProfiler. Use when the user wants to bump the version, create a release, or tag a new version.
+disable-model-invocation: true
+allowed-tools: Bash(git *) Bash(gh *) Read Edit
+---
+
+## gProfiler Version Release Process
+
+**Context from history:** 22 version bumps in 3 years (1.34.0 → 1.56.2)
+
+### Current Version
+
+```!
+grep -E "^__version__" gprofiler/__init__.py 2>/dev/null || echo "Version not found"
+```
+
+### Release Steps
+
+**Step 1: Update Version**
+
+Edit `gprofiler/__init__.py`:
+```python
+__version__ = "X.Y.Z"
+```
+
+**Step 2: Create PR**
+```bash
+git checkout -b bump-version-X.Y.Z
+git add gprofiler/__init__.py
+git commit -m "Bump version to X.Y.Z"
+git push -u origin bump-version-X.Y.Z
+gh pr create --title "Bump version to X.Y.Z" --body "Version bump for release X.Y.Z"
+```
+
+**Step 3: Merge PR**
+
+Wait for CI to pass, then merge.
+
+**Step 4: Create Tag**
+```bash
+git checkout master
+git pull
+git tag vX.Y.Z
+git push origin vX.Y.Z
+```
+
+### CI/CD on Tag Push
+
+When a tag is pushed, `.github/workflows/build-test-deploy.yml`:
+1. Builds executables (x86_64, aarch64)
+2. Builds Docker containers
+3. Runs full test suite
+4. Deploys to Docker Hub (`intel/gprofiler:X.Y.Z`, `intel/gprofiler:latest`)
+5. Creates GitHub release with executables
+
+### Version Numbering
+
+Semantic versioning: `MAJOR.MINOR.PATCH`
+- **MAJOR:** Breaking changes
+- **MINOR:** New features, backward compatible
+- **PATCH:** Bug fixes, security updates
+
+### Recent Version History
+
+From git history:
+```
+1.56.2 - Current
+1.56.1
+1.56.0
+...
+1.34.0 - ~3 years ago
+```
+
+### Pre-Release Checklist
+
+- [ ] All tests pass
+- [ ] Linters pass
+- [ ] CHANGELOG updated (if maintained)
+- [ ] README updated for new features
+- [ ] Version number follows semantic versioning
+- [ ] No pending security issues
+
+### Hotfix Release
+
+For urgent fixes:
+```bash
+# Branch from tag
+git checkout vX.Y.Z
+git checkout -b hotfix-X.Y.Z+1
+
+# Make fix
+# ...
+
+# Update version
+# Edit gprofiler/__init__.py
+
+# Create PR to master AND tag
+git push -u origin hotfix-X.Y.Z+1
+gh pr create --title "Hotfix: <description>" --body "..."
+```
+
+### Docker Hub Images
+
+After release:
+- `intel/gprofiler:latest`
+- `intel/gprofiler:X.Y.Z`
+
+### GitHub Release
+
+Created automatically with:
+- `gprofiler_x86_64` executable
+- `gprofiler_aarch64` executable
+- Release notes (from tag message or PR description)
+
+---
+
+## TODO: Skill Content to Add
+
+- [ ] **Add version history table** - Recent versions with highlights
+- [ ] **Add release artifact checksums** - How to verify downloads
+- [ ] **Add Docker Hub tag convention** - Tagging strategy explanation
+- [ ] **Add rollback procedure** - How to revert a bad release
+- [ ] **Add release announcement template** - Standard release notes format
+- [ ] **Add compatibility notes** - What to check for breaking changes
+- [ ] **Add post-release verification** - Steps to verify successful release
+- [ ] **Add emergency hotfix process** - Detailed hotfix workflow

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -1,0 +1,44 @@
+name: Fast unit tests
+
+permissions:
+  contents: read
+
+# Fast, in-process acceptance/spec tests for the dynamic-profiling command
+# queue and heartbeat workload inventory. These run in milliseconds and need no
+# container runtime, unlike the docker-based end-to-end suite under tests/.
+on:
+  pull_request:
+    paths:
+      - "gprofiler/dynamic_profiling_management/**"
+      - "gprofiler/metadata/heartbeat_metadata.py"
+      - "tests_fast/**"
+      - ".github/workflows/unit-tests.yml"
+  workflow_dispatch:
+
+jobs:
+  fast-tests:
+    strategy:
+      matrix:
+        python-version:
+          - "3.10"
+          - "3.11"
+          - "3.12"
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v4
+
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Install test dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install pytest psutil
+
+      - name: Run fast unit tests
+        run: python -m pytest tests_fast -q

--- a/docs/WORKLOAD_LEVEL_PROFILING_SPEC.md
+++ b/docs/WORKLOAD_LEVEL_PROFILING_SPEC.md
@@ -139,6 +139,53 @@ This design preserves compatibility with existing backends because:
 - the backend may ignore workload metadata safely
 - command delivery and completion flows are unchanged
 
+## Acceptance Tests
+
+These acceptance criteria define "done" for the agent side of workload-level
+profiling. They are written as Given/When/Then so they can drive spec-first
+development and be implemented as automated unit/integration tests.
+
+### Workload inventory reporting
+
+- **AT-A1 — Inventory attached when runtime available.** *Given* a supported
+  container runtime is present, *When* the agent builds a heartbeat, *Then* the
+  payload includes `containers[]` where each entry carries container identity,
+  best-effort `namespace`/`pod_name`/`workload_name`/`workload_kind`, and the
+  `processes[]` (pid + process_name) running in that container.
+- **AT-A2 — No runtime is graceful.** *Given* no container runtime is available,
+  *When* the heartbeat is built, *Then* `containers` is empty and the heartbeat
+  is still sent successfully (control plane is never blocked).
+- **AT-A3 — Discovery failure is non-fatal.** *Given* workload discovery raises
+  an error, *When* the heartbeat is built, *Then* the failure is logged as
+  diagnostic (not fatal), `containers` is published empty, and both heartbeat
+  delivery and command receipt continue.
+- **AT-A4 — Workload-name inference.** *Given* pod labels and/or a
+  ReplicaSet/StatefulSet-shaped pod name, *When* inferring a workload name,
+  *Then* the agent uses `app.kubernetes.io/name`, then `app`, then pod-name
+  normalization, treating the result as a best-effort selector only.
+- **AT-A5 — Agent-pod env fallback.** *Given* `POD_NAMESPACE`/`POD_NAME` are set
+  and richer sources are unavailable, *When* building metadata for the agent's
+  own pod, *Then* those env values are used as fallback.
+
+### Command execution (unchanged model)
+
+- **AT-A6 — Host-level command.** *Given* a host-scoped command for
+  `(hostname, service_name)`, *When* executed, *Then* the agent profiles
+  host-wide exactly as before workload support.
+- **AT-A7 — PID-level command.** *Given* a command whose config contains
+  backend-resolved `pids`, *When* executed, *Then* only those PIDs are profiled
+  via the existing `pids_to_profile` path; no second targeting model is
+  introduced in the agent.
+- **AT-A8 — Completion reporting.** *Given* a command finishes (success or
+  failure), *When* the agent reports back, *Then* it uses the existing
+  completion control plane keyed by `command_id`.
+
+### Compatibility
+
+- **AT-A9 — Additive heartbeat fields.** *Given* a backend that predates workload
+  support, *When* it receives the enriched heartbeat, *Then* it can ignore the
+  new fields without error and host-based behavior is unaffected.
+
 ## Spec-Driven Development Workflow
 
 Future workload-related changes in this repo should follow this sequence:

--- a/docs/WORKLOAD_LEVEL_PROFILING_SPEC.md
+++ b/docs/WORKLOAD_LEVEL_PROFILING_SPEC.md
@@ -1,0 +1,159 @@
+# Workload-Level Profiling Spec for gProfiler
+
+## Purpose
+
+This spec defines the agent-side contract for workload-level profiling support.
+It is intended to support spec-driven development for future heartbeat, targeting,
+and Kubernetes metadata changes in the `gprofiler` repo.
+
+The key idea is that the agent keeps host-command execution semantics, but
+publishes richer workload inventory through heartbeat metadata so the backend can
+resolve workload selections into concrete host and process targets.
+
+## Scope
+
+This spec covers:
+
+- heartbeat payload extensions sent by the gProfiler agent
+- best-effort workload inventory discovery from container runtime metadata
+- compatibility constraints with the existing host-based command queue
+- expected follow-up workflow for spec-driven development
+
+This spec does not redefine profile storage, flamegraph rendering, or
+Performance Studio UI behavior beyond the contract the agent must satisfy.
+
+## Goals
+
+1. Allow Performance Studio to target namespaces, pods, containers, and
+   processes without replacing the existing host-based command-delivery model.
+2. Keep the agent implementation additive and backward compatible.
+3. Make workload targeting safe even when Kubernetes metadata is partial.
+4. Ensure future changes start by updating this spec before code changes land.
+
+## Non-Goals
+
+- introducing a new agent-side workload scheduler
+- turning commands into pod-native or container-native execution primitives
+- guaranteeing perfect Kubernetes workload-name inference across all runtimes
+- supporting workload discovery without a visible container runtime
+
+## Design Summary
+
+The gProfiler agent continues to:
+
+- receive commands per `(hostname, service_name)`
+- execute profiling based on resolved PIDs or host-wide settings
+- report command completion via the existing heartbeat control plane
+
+The new behavior is:
+
+- collect best-effort container inventory during heartbeat generation
+- attach Kubernetes-aware metadata when available
+- publish process membership by container so the backend can resolve workload
+  selections into host/PID mappings before command creation
+
+## Heartbeat Contract
+
+The heartbeat payload remains host-centric but includes optional workload fields:
+
+```json
+{
+  "ip_address": "10.0.0.10",
+  "hostname": "node-a",
+  "service_name": "checkout",
+  "agent_version": "1.2.3",
+  "run_mode": "k8s",
+  "namespace": "observability",
+  "pod_name": "gprofiler-abcde",
+  "containers": [
+    {
+      "container_id": "abc123",
+      "container_name": "checkout",
+      "runtime": "containerd",
+      "namespace": "shop",
+      "pod_name": "checkout-7f8d9",
+      "workload_name": "checkout",
+      "workload_kind": "k8s",
+      "processes": [
+        {
+          "pid": 1234,
+          "process_name": "java"
+        }
+      ]
+    }
+  ]
+}
+```
+
+## Metadata Discovery Rules
+
+The agent should use the following sources in order of confidence:
+
+1. container runtime inventory from `granulate_utils.containers.client`
+2. runtime labels such as:
+   - `io.kubernetes.pod.namespace`
+   - `io.kubernetes.pod.name`
+   - `io.kubernetes.container.name`
+3. process-to-container resolution via cgroup/container-id lookup
+4. environment metadata for the agent pod itself, such as `POD_NAMESPACE` and
+   `POD_NAME`
+
+If no container runtime is available, the agent must keep heartbeat delivery
+working and omit workload inventory rather than failing the control plane.
+
+## Workload Name Inference
+
+The agent may infer a workload name using:
+
+- `app.kubernetes.io/name`
+- `app`
+- pod-name normalization for ReplicaSet- and StatefulSet-shaped pod names
+
+This inference is best-effort only. The backend must treat these values as
+helpful selectors, not as immutable workload identifiers.
+
+## Command-Execution Model
+
+The agent does not change how profiling commands are executed:
+
+- host-level selections remain host-scoped commands
+- workload-level selections are backend-resolved into host/PID mappings
+- process profiling still uses existing `pids_to_profile` behavior
+
+This intentionally avoids introducing a second targeting model inside the agent.
+
+## Failure Handling
+
+The agent must:
+
+- continue sending heartbeats if workload discovery fails
+- log discovery failures as diagnostic information, not fatal errors
+- avoid blocking command receipt on container/runtime metadata issues
+- publish empty `containers` when inventory cannot be collected
+
+## Compatibility
+
+This design preserves compatibility with existing backends because:
+
+- all new heartbeat fields are additive
+- the backend may ignore workload metadata safely
+- command delivery and completion flows are unchanged
+
+## Spec-Driven Development Workflow
+
+Future workload-related changes in this repo should follow this sequence:
+
+1. Update this spec first.
+2. Describe any heartbeat contract changes explicitly.
+3. Document compatibility and rollout behavior.
+4. Implement code only after the spec reflects the intended design.
+5. Keep the implementation aligned with `.claude/skills/implement-from-spec`.
+
+## Future Extensions
+
+Potential follow-ups that should begin as spec changes:
+
+- stable workload identifiers beyond best-effort names
+- richer workload kinds such as `deployment`, `daemonset`, `job`, and `cronjob`
+- container-image metadata for targeting/debugging
+- workload-aware continuous retargeting when pod membership changes

--- a/gprofiler/dynamic_profiling_management/heartbeat.py
+++ b/gprofiler/dynamic_profiling_management/heartbeat.py
@@ -26,6 +26,7 @@ import requests
 from gprofiler.dynamic_profiling_management.ad_hoc import AdhocProfilerSlot
 from gprofiler.dynamic_profiling_management.command_control import CommandManager, ProfilingCommand
 from gprofiler.dynamic_profiling_management.continuous import ContinuousProfilerSlot
+from gprofiler.metadata.heartbeat_metadata import HeartbeatMetadataCollector
 from gprofiler.metadata.system_metadata import get_hostname
 from gprofiler.metrics_publisher import (
     MetricsPublisher,
@@ -77,6 +78,7 @@ class HeartbeatClient:
 
         self._init_session()
         self.pmu_manager = get_pmu_manager()
+        self.heartbeat_metadata_collector = HeartbeatMetadataCollector()
 
         if self.server_token:
             self.session.headers.update(
@@ -157,6 +159,7 @@ class HeartbeatClient:
     def send_heartbeat(self) -> Optional[Dict[str, Any]]:
         try:
             perf_supported_events = self.pmu_manager.get_supported_events()
+            inventory_metadata = self.heartbeat_metadata_collector.collect()
             heartbeat_data = {
                 "ip_address": self.ip_address,
                 "hostname": self.hostname,
@@ -167,6 +170,7 @@ class HeartbeatClient:
                 "received_command_ids": list(self.received_command_ids),
                 "executed_command_ids": list(self.executed_command_ids),
                 "perf_supported_events": perf_supported_events,
+                **inventory_metadata,
             }
             url = f"{self.api_server}/api/metrics/heartbeat"
             response = self.session.post(url, json=heartbeat_data, timeout=30)

--- a/gprofiler/metadata/heartbeat_metadata.py
+++ b/gprofiler/metadata/heartbeat_metadata.py
@@ -1,0 +1,141 @@
+#
+# Copyright (C) 2022 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+import os
+import re
+import time
+from typing import Any, Dict, List, Optional
+
+from granulate_utils.containers.client import ContainersClient
+from granulate_utils.exceptions import NoContainerRuntimesError
+from granulate_utils.linux.containers import get_process_container_id
+from psutil import NoSuchProcess, Process, process_iter
+
+from gprofiler import __version__
+from gprofiler.log import get_logger_adapter
+from gprofiler.metadata.system_metadata import get_run_mode
+
+logger = get_logger_adapter(__name__)
+
+REPLICASET_SUFFIX_RE = re.compile(r"^(?P<name>.+)-[a-f0-9]{8,10}-[a-z0-9]{5}$")
+STATEFULSET_SUFFIX_RE = re.compile(r"^(?P<name>.+)-\d+$")
+
+
+def _best_effort_workload_name(pod_name: Optional[str], labels: Dict[str, str]) -> Optional[str]:
+    if labels.get("app.kubernetes.io/name"):
+        return labels["app.kubernetes.io/name"]
+    if labels.get("app"):
+        return labels["app"]
+    if pod_name is None:
+        return None
+
+    match = REPLICASET_SUFFIX_RE.match(pod_name)
+    if match is not None:
+        return str(match.group("name"))
+
+    match = STATEFULSET_SUFFIX_RE.match(pod_name)
+    if match is not None:
+        return str(match.group("name"))
+
+    return pod_name
+
+
+class HeartbeatMetadataCollector:
+    def __init__(self, refresh_interval_seconds: int = 30) -> None:
+        self._refresh_interval_seconds = refresh_interval_seconds
+        self._last_snapshot_at = 0.0
+        self._last_snapshot: Dict[str, Any] = {
+            "agent_version": __version__,
+            "run_mode": get_run_mode(),
+            "namespace": os.environ.get("POD_NAMESPACE"),
+            "pod_name": os.environ.get("POD_NAME"),
+            "containers": [],
+        }
+        try:
+            self._containers_client: Optional[ContainersClient] = ContainersClient()
+        except NoContainerRuntimesError:
+            logger.info("No container runtime found for heartbeat workload inventory")
+            self._containers_client = None
+
+    def collect(self) -> Dict[str, Any]:
+        now = time.monotonic()
+        if now - self._last_snapshot_at < self._refresh_interval_seconds:
+            return self._last_snapshot
+
+        containers = self._collect_containers()
+        self._last_snapshot = {
+            "agent_version": __version__,
+            "run_mode": get_run_mode(),
+            "namespace": os.environ.get("POD_NAMESPACE"),
+            "pod_name": os.environ.get("POD_NAME"),
+            "containers": containers,
+        }
+        self._last_snapshot_at = now
+        return self._last_snapshot
+
+    def _collect_containers(self) -> List[Dict[str, Any]]:
+        if self._containers_client is None:
+            return []
+
+        try:
+            containers = list(self._containers_client.list_containers())
+        except Exception:
+            logger.warning("Failed to enumerate containers for heartbeat inventory", exc_info=True)
+            return []
+
+        processes_by_container: Dict[str, List[Dict[str, Any]]] = {}
+        for process in process_iter(["pid", "name"]):
+            try:
+                container_id = get_process_container_id(Process(process.pid))
+            except NoSuchProcess:
+                continue
+            except Exception:
+                continue
+
+            if container_id is None:
+                continue
+
+            processes_by_container.setdefault(container_id, []).append(
+                {
+                    "pid": process.pid,
+                    "process_name": process.info.get("name") or "",
+                }
+            )
+
+        workload_inventory: List[Dict[str, Any]] = []
+        for container in containers:
+            labels = getattr(container, "labels", {}) or {}
+            namespace = labels.get("io.kubernetes.pod.namespace")
+            pod_name = labels.get("io.kubernetes.pod.name")
+            container_name = labels.get("io.kubernetes.container.name") or getattr(container, "name", None)
+
+            workload_inventory.append(
+                {
+                    "container_id": getattr(container, "id", None),
+                    "container_name": container_name,
+                    "runtime": getattr(container, "runtime", None),
+                    "namespace": namespace,
+                    "pod_name": pod_name,
+                    "workload_name": _best_effort_workload_name(pod_name, labels),
+                    "workload_kind": "k8s" if namespace or pod_name else "container",
+                    "processes": sorted(
+                        processes_by_container.get(getattr(container, "id", ""), []),
+                        key=lambda process_info: process_info["pid"],
+                    ),
+                }
+            )
+
+        return workload_inventory

--- a/tests_fast/conftest.py
+++ b/tests_fast/conftest.py
@@ -1,0 +1,45 @@
+#
+# Copyright (C) 2022 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""
+Setup for the *fast* agent acceptance tests.
+
+These tests are intentionally kept out of the ``tests/`` package: that package's
+conftest imports docker and the full profiler stack for end-to-end runs, which is
+slow and needs a container runtime. The tests here are pure/in-process and only
+depend (at most) on ``granulate_utils`` and ``psutil``, so they run in
+milliseconds in CI.
+
+This conftest makes the repo root and the vendored ``granulate-utils`` source
+importable, so ``gprofiler.*`` and ``granulate_utils.*`` resolve without an
+editable install.
+"""
+
+import sys
+from pathlib import Path
+
+# tests_fast/ -> parents[1] == repo root (the directory containing gprofiler/)
+_REPO_ROOT = Path(__file__).resolve().parents[1]
+
+_CANDIDATE_PATHS = (
+    _REPO_ROOT,
+    _REPO_ROOT / "granulate-utils",  # vendored granulate_utils source
+)
+
+for _path in _CANDIDATE_PATHS:
+    _str = str(_path)
+    if _path.is_dir() and _str not in sys.path:
+        sys.path.insert(0, _str)

--- a/tests_fast/test_command_queue_spec.py
+++ b/tests_fast/test_command_queue_spec.py
@@ -1,0 +1,161 @@
+#
+# Copyright (C) 2022 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""
+Fast acceptance tests for the agent command queue (command control plane).
+
+WORKLOAD_LEVEL_PROFILING_SPEC.md keeps the *command-execution model unchanged*
+(AT-A6/AT-A7/AT-A8): the agent still receives commands and runs them through the
+existing prioritized queue. This suite locks that queue behavior down:
+
+* stop > adhoc > continuous priority
+* continuous is a singleton slot (a new continuous command replaces the old one)
+* dequeue is position- and id-checked (idempotent completion reporting, AT-A8)
+* stop/adhoc cannot be paused; only continuous can
+
+``command_control`` is pure stdlib, so we load it directly by path to avoid
+importing the dynamic_profiling_management package (whose __init__ pulls the full
+profiler dependency stack). This keeps the suite dependency-free and instant.
+"""
+
+import datetime
+import importlib.util
+from pathlib import Path
+
+import pytest
+
+_CC_PATH = (
+    Path(__file__).resolve().parents[1]
+    / "gprofiler"
+    / "dynamic_profiling_management"
+    / "command_control.py"
+)
+
+_spec = importlib.util.spec_from_file_location("command_control_under_test", _CC_PATH)
+command_control = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(command_control)
+
+CommandManager = command_control.CommandManager
+ProfilingCommand = command_control.ProfilingCommand
+
+
+def _cmd(command_id, command_type="start", is_continuous=False, profiling_command=None):
+    return ProfilingCommand(
+        command_id=command_id,
+        command_type=command_type,
+        profiling_command=profiling_command or {},
+        is_continuous=is_continuous,
+        timestamp=datetime.datetime(2024, 1, 1),
+    )
+
+
+@pytest.fixture
+def manager():
+    return CommandManager()
+
+
+class TestQueuePrioritySpec:
+    def test_empty_manager_has_no_next_command(self, manager):
+        assert manager.get_next_command() is None
+        assert manager.has_queued_commands() is False
+
+    def test_stop_beats_adhoc_and_continuous(self, manager):
+        manager.enqueue_command(_cmd("cont", is_continuous=True))
+        manager.enqueue_command(_cmd("adhoc"))
+        manager.enqueue_command(_cmd("stop", command_type="stop"))
+        assert manager.get_next_command().command_id == "stop"
+
+    def test_adhoc_beats_continuous(self, manager):
+        manager.enqueue_command(_cmd("cont", is_continuous=True))
+        manager.enqueue_command(_cmd("adhoc"))
+        assert manager.get_next_command().command_id == "adhoc"
+
+    def test_adhoc_is_fifo(self, manager):
+        manager.enqueue_command(_cmd("a1"))
+        manager.enqueue_command(_cmd("a2"))
+        assert manager.get_next_command().command_id == "a1"
+
+    def test_get_next_is_a_peek_not_a_pop(self, manager):
+        manager.enqueue_command(_cmd("adhoc"))
+        assert manager.get_next_command().command_id == "adhoc"
+        # Peeking twice returns the same command (not removed).
+        assert manager.get_next_command().command_id == "adhoc"
+
+
+class TestContinuousSingletonSpec:
+    def test_new_continuous_replaces_previous(self, manager):
+        manager.enqueue_command(_cmd("cont-1", is_continuous=True))
+        manager.enqueue_command(_cmd("cont-2", is_continuous=True))
+        assert len(manager.continuous_queue) == 1
+        assert manager.get_next_command().command_id == "cont-2"
+
+
+class TestDequeueSpec:
+    def test_dequeue_removes_head_by_id(self, manager):
+        manager.enqueue_command(_cmd("adhoc"))
+        assert manager.dequeue_command("adhoc") is True
+        assert manager.has_queued_commands() is False
+
+    def test_dequeue_wrong_id_is_noop(self, manager):
+        manager.enqueue_command(_cmd("adhoc"))
+        assert manager.dequeue_command("nope") is False
+        assert manager.get_next_command().command_id == "adhoc"
+
+    def test_dequeue_is_idempotent(self, manager):
+        # AT-A8: repeated completion reports for the same command must not error
+        # or remove a different command.
+        manager.enqueue_command(_cmd("adhoc"))
+        assert manager.dequeue_command("adhoc") is True
+        assert manager.dequeue_command("adhoc") is False
+
+    def test_stop_has_priority_for_dequeue(self, manager):
+        manager.enqueue_command(_cmd("adhoc"))
+        manager.enqueue_command(_cmd("stop", command_type="stop"))
+        # adhoc is not at the head of any queue that outranks stop, so removing it
+        # directly still works because it is the head of the adhoc queue...
+        assert manager.dequeue_command("stop") is True
+        assert manager.get_next_command().command_id == "adhoc"
+
+
+class TestPauseSpec:
+    def test_continuous_can_be_paused_and_blocks_dequeue(self, manager):
+        manager.enqueue_command(_cmd("cont", is_continuous=True))
+        assert manager.pause_command("cont") is True
+        # A paused continuous command must not be dequeued out from under a pause.
+        assert manager.dequeue_command("cont") is False
+
+    def test_stop_and_adhoc_cannot_be_paused(self, manager):
+        manager.enqueue_command(_cmd("stop", command_type="stop"))
+        manager.enqueue_command(_cmd("adhoc"))
+        assert manager.pause_command("stop") is False
+        assert manager.pause_command("adhoc") is False
+
+
+class TestLifecycleSpec:
+    def test_clear_queues_empties_everything(self, manager):
+        manager.enqueue_command(_cmd("stop", command_type="stop"))
+        manager.enqueue_command(_cmd("adhoc"))
+        manager.enqueue_command(_cmd("cont", is_continuous=True))
+        manager.clear_queues()
+        assert manager.has_queued_commands() is False
+        assert manager.get_next_command() is None
+
+    def test_pids_travel_in_the_command_payload(self, manager):
+        # AT-A7: backend-resolved PIDs ride along in the command payload the queue
+        # carries; the queue itself is targeting-agnostic.
+        payload = {"pids": [1234, 5678], "duration": 60}
+        manager.enqueue_command(_cmd("adhoc", profiling_command=payload))
+        assert manager.get_next_command().profiling_command["pids"] == [1234, 5678]

--- a/tests_fast/test_workload_inventory_spec.py
+++ b/tests_fast/test_workload_inventory_spec.py
@@ -1,0 +1,247 @@
+#
+# Copyright (C) 2022 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""
+Fast acceptance tests for agent heartbeat workload inventory.
+
+Covers WORKLOAD_LEVEL_PROFILING_SPEC.md (gProfiler side):
+
+* AT-A1 — inventory attached when a runtime is available
+* AT-A2 — no runtime is graceful (empty containers, heartbeat still built)
+* AT-A3 — discovery failure is non-fatal (logged, empty containers)
+* AT-A4 — best-effort workload-name inference (labels > pod-name normalization)
+* AT-A5 — agent-pod env fallback (POD_NAMESPACE / POD_NAME)
+
+``gprofiler.metadata.heartbeat_metadata`` normally imports the full
+``granulate_utils`` container stack (grpc/docker) plus glogger. Those are agent
+runtime concerns, not what this spec is about, so we load the module in
+isolation with light stubs for its heavy imports. This keeps the suite instant
+and dependency-free while still exercising the real inventory-building code.
+"""
+
+import importlib.util
+import sys
+import types
+from pathlib import Path
+
+import pytest
+
+pytest.importorskip("psutil", reason="psutil is required to build heartbeat inventory")
+
+
+class _StubContainersClient:
+    """Placeholder; tests set collector._containers_client directly."""
+
+
+class _StubNoContainerRuntimesError(Exception):
+    pass
+
+
+def _install_stub_modules():
+    """Register lightweight stand-ins for heartbeat_metadata's heavy imports."""
+
+    def _mod(name, **attrs):
+        module = types.ModuleType(name)
+        for key, value in attrs.items():
+            setattr(module, key, value)
+        sys.modules[name] = module
+        return module
+
+    # granulate_utils.* container stack (grpc/docker) -> stubs
+    _mod("granulate_utils")
+    _mod("granulate_utils.containers")
+    _mod("granulate_utils.containers.client", ContainersClient=_StubContainersClient)
+    _mod("granulate_utils.exceptions", NoContainerRuntimesError=_StubNoContainerRuntimesError)
+    _mod("granulate_utils.linux")
+    _mod("granulate_utils.linux.containers", get_process_container_id=lambda proc: None)
+
+    # gprofiler.log needs glogger; gprofiler.metadata.system_metadata needs
+    # granulate_utils. Stub just the symbols heartbeat_metadata imports.
+    import logging
+
+    _mod("gprofiler.log", get_logger_adapter=lambda name: logging.getLogger(name))
+    _mod("gprofiler.metadata.system_metadata", get_run_mode=lambda: "k8s")
+
+
+def _load_heartbeat_metadata():
+    _install_stub_modules()
+    module_path = (
+        Path(__file__).resolve().parents[1] / "gprofiler" / "metadata" / "heartbeat_metadata.py"
+    )
+    spec = importlib.util.spec_from_file_location("heartbeat_metadata_under_test", module_path)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+hb = _load_heartbeat_metadata()
+
+
+# ---------------------------------------------------------------------------
+# AT-A4 — workload-name inference
+# ---------------------------------------------------------------------------
+
+
+class TestWorkloadNameInferenceSpec:
+    def test_app_kubernetes_io_name_label_wins(self):
+        name = hb._best_effort_workload_name(
+            "web-5d4b8c7f9c-abcde",
+            {"app.kubernetes.io/name": "checkout", "app": "other"},
+        )
+        assert name == "checkout"
+
+    def test_app_label_is_second_choice(self):
+        assert hb._best_effort_workload_name("web-5d4b8c7f9c-abcde", {"app": "cart"}) == "cart"
+
+    def test_replicaset_pod_name_is_normalized(self):
+        assert hb._best_effort_workload_name("web-5d4b8c7f9c-abcde", {}) == "web"
+
+    def test_statefulset_pod_name_is_normalized(self):
+        assert hb._best_effort_workload_name("postgres-0", {}) == "postgres"
+
+    def test_plain_pod_name_is_returned_as_is(self):
+        assert hb._best_effort_workload_name("standalone", {}) == "standalone"
+
+    def test_no_pod_name_and_no_labels_is_none(self):
+        assert hb._best_effort_workload_name(None, {}) is None
+
+
+# ---------------------------------------------------------------------------
+# Collector behavior (AT-A1/AT-A2/AT-A3/AT-A5)
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def collector():
+    # __init__ tries to build a real ContainersClient (our stub); tests then set
+    # _containers_client explicitly to control the runtime scenario.
+    inst = object.__new__(hb.HeartbeatMetadataCollector)
+    inst._refresh_interval_seconds = 0
+    inst._last_snapshot_at = 0.0
+    inst._last_snapshot = {"containers": []}
+    inst._containers_client = None
+    return inst
+
+
+class _FakeContainer:
+    def __init__(self, id, name, runtime, labels):
+        self.id = id
+        self.name = name
+        self.runtime = runtime
+        self.labels = labels
+
+
+class _FakeProc:
+    def __init__(self, pid, name):
+        self.pid = pid
+        self.info = {"pid": pid, "name": name}
+
+
+class TestNoRuntimeSpec:
+    def test_no_runtime_yields_empty_inventory(self, collector):
+        # AT-A2
+        collector._containers_client = None
+        assert collector._collect_containers() == []
+
+    def test_collect_still_builds_a_heartbeat_snapshot(self, collector, monkeypatch):
+        # AT-A2: control plane never blocked; snapshot is well-formed.
+        monkeypatch.setenv("POD_NAMESPACE", "obs")
+        monkeypatch.setenv("POD_NAME", "gprofiler-x")
+        snapshot = collector.collect()
+        assert snapshot["containers"] == []
+        assert "agent_version" in snapshot
+        assert snapshot["run_mode"] == "k8s"
+
+
+class TestDiscoveryFailureSpec:
+    def test_list_containers_error_is_non_fatal(self, collector):
+        # AT-A3
+        class _Boom:
+            def list_containers(self):
+                raise RuntimeError("runtime exploded")
+
+        collector._containers_client = _Boom()
+        assert collector._collect_containers() == []
+
+
+class TestEnvFallbackSpec:
+    def test_pod_namespace_and_name_come_from_env(self, collector, monkeypatch):
+        # AT-A5
+        monkeypatch.setenv("POD_NAMESPACE", "observability")
+        monkeypatch.setenv("POD_NAME", "gprofiler-abcde")
+        snapshot = collector.collect()
+        assert snapshot["namespace"] == "observability"
+        assert snapshot["pod_name"] == "gprofiler-abcde"
+
+
+class TestInventoryAttachedSpec:
+    def test_inventory_carries_identity_metadata_and_processes(self, collector, monkeypatch):
+        # AT-A1: with a runtime, each container entry has identity, best-effort
+        # k8s metadata, and its process list (pid + process_name).
+        container = _FakeContainer(
+            id="c1",
+            name="checkout",
+            runtime="containerd",
+            labels={
+                "io.kubernetes.pod.namespace": "shop",
+                "io.kubernetes.pod.name": "checkout-7f8d9",
+                "io.kubernetes.container.name": "checkout",
+                "app.kubernetes.io/name": "checkout",
+            },
+        )
+
+        class _Client:
+            def list_containers(self):
+                return [container]
+
+        collector._containers_client = _Client()
+        monkeypatch.setattr(hb, "Process", lambda pid: pid, raising=True)
+        monkeypatch.setattr(hb, "get_process_container_id", lambda proc: "c1", raising=True)
+        monkeypatch.setattr(
+            hb, "process_iter", lambda fields: [_FakeProc(1234, "java"), _FakeProc(20, "sh")]
+        )
+
+        inventory = collector._collect_containers()
+        assert len(inventory) == 1
+        entry = inventory[0]
+        assert entry["container_id"] == "c1"
+        assert entry["container_name"] == "checkout"
+        assert entry["namespace"] == "shop"
+        assert entry["pod_name"] == "checkout-7f8d9"
+        assert entry["workload_name"] == "checkout"
+        assert entry["workload_kind"] == "k8s"
+        # processes are sorted by pid
+        assert entry["processes"] == [
+            {"pid": 20, "process_name": "sh"},
+            {"pid": 1234, "process_name": "java"},
+        ]
+
+    def test_non_k8s_container_is_labeled_container_kind(self, collector, monkeypatch):
+        container = _FakeContainer(id="d1", name="redis", runtime="docker", labels={})
+
+        class _Client:
+            def list_containers(self):
+                return [container]
+
+        collector._containers_client = _Client()
+        monkeypatch.setattr(hb, "Process", lambda pid: pid, raising=True)
+        monkeypatch.setattr(hb, "get_process_container_id", lambda proc: None, raising=True)
+        monkeypatch.setattr(hb, "process_iter", lambda fields: [])
+
+        entry = collector._collect_containers()[0]
+        assert entry["workload_kind"] == "container"
+        assert entry["namespace"] is None
+        assert entry["processes"] == []


### PR DESCRIPTION
## Summary
- publish workload inventory in agent heartbeats so the backend can resolve namespace, pod, container, and process selections without changing host-based command execution
- add a best-effort heartbeat metadata collector for container, pod, workload, and process inventory
- sync the Intel agent guidance and add a workload design spec so future iterations can follow a spec-driven workflow

## Test plan
- [x] `python3 -m compileall gprofiler/dynamic_profiling_management/heartbeat.py gprofiler/metadata/heartbeat_metadata.py`
- [x] `git diff --check`
- [ ] Run heartbeat flow against a local Performance Studio instance
- [ ] Validate workload inventory on a Kubernetes-backed agent

Made with [Cursor](https://cursor.com)