### PR TITLE
Support all async-profiler modes via the heartbeat dynamic profiling system

### DIFF
--- a/docs/HEARTBEAT_SYSTEM_README.md
+++ b/docs/HEARTBEAT_SYSTEM_README.md
@@ -293,9 +293,38 @@ The `profiler_configs` object in `combined_config` controls which profilers are 
 
 ### Java Async Profiler
 
-- `{"enabled": true, "time": "cpu"}` — CPU time sampling
-- `{"enabled": true, "time": "wall"}` — Wall clock sampling
-- `{"enabled": false}` — Disabled
+The `async_profiler` key accepts a configuration dict or the shorthand string `"disabled"`.
+
+**Dict format:**
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `enabled` | bool | no (default `true`) | Set to `false` to disable Java profiling entirely |
+| `time` | string | no (default `"cpu"`) | Profiling mode — see table below |
+| `alloc_interval` | string | no (default `"2mb"`) | Allocation sampling interval; only used when `time` is `"alloc"` |
+
+**`time` mode values:**
+
+| Value | async-profiler mode | Description |
+|---|---|---|
+| `"cpu"` | `cpu` | CPU time via `perf_events` |
+| `"itimer"` | `itimer` | CPU time via `SIGPROF` (fallback when perf events are unavailable) |
+| `"wall"` | `wall` | Wall-clock time (includes threads waiting on I/O or sleeping) |
+| `"alloc"` | `alloc` | Allocation profiling; sets `profiling_mode` to `"allocation"`. Interval is controlled by `alloc_interval` (e.g. `"512kb"`, `"2mb"`) |
+| `"auto"` | `cpu` or `itimer` | Selects `cpu` if perf events are available on the host; falls back to `itimer` |
+
+**Examples:**
+
+```json
+{"enabled": true, "time": "cpu"}
+{"enabled": true, "time": "itimer"}
+{"enabled": true, "time": "wall"}
+{"enabled": true, "time": "alloc", "alloc_interval": "512kb"}
+{"enabled": true, "time": "auto"}
+{"enabled": false}
+```
+
+**String shorthand:** `"disabled"` is equivalent to `{"enabled": false}` and is supported for backward compatibility.
 
 ### Python
 

--- a/docs/HEARTBEAT_SYSTEM_README.md
+++ b/docs/HEARTBEAT_SYSTEM_README.md
@@ -301,7 +301,7 @@ The `async_profiler` key accepts a configuration dict or the shorthand string `"
 |---|---|---|---|
 | `enabled` | bool | no (default `true`) | Set to `false` to disable Java profiling entirely |
 | `time` | string | no (default `"cpu"`) | Profiling mode — see table below |
-| `alloc_interval` | string | no (default `"2mb"`) | Allocation sampling interval; only used when `time` is `"alloc"` |
+| `alloc_interval` | string | no (default `"2MB"`) | Allocation sampling interval; only used when `time` is `"alloc"`. Uses [bitmath](https://pypi.org/project/bitmath/) notation (e.g. `"512KiB"`, `"2MB"`) |
 
 **`time` mode values:**
 
@@ -310,7 +310,7 @@ The `async_profiler` key accepts a configuration dict or the shorthand string `"
 | `"cpu"` | `cpu` | CPU time via `perf_events` |
 | `"itimer"` | `itimer` | CPU time via `SIGPROF` (fallback when perf events are unavailable) |
 | `"wall"` | `wall` | Wall-clock time (includes threads waiting on I/O or sleeping) |
-| `"alloc"` | `alloc` | Allocation profiling; sets `profiling_mode` to `"allocation"`. Interval is controlled by `alloc_interval` (e.g. `"512kb"`, `"2mb"`) |
+| `"alloc"` | `alloc` | Allocation profiling; sets `profiling_mode` to `"allocation"`. Interval is controlled by `alloc_interval` (e.g. `"512KiB"`, `"2MB"`) |
 | `"auto"` | `cpu` or `itimer` | Selects `cpu` if perf events are available on the host; falls back to `itimer` |
 
 **Examples:**
@@ -319,7 +319,7 @@ The `async_profiler` key accepts a configuration dict or the shorthand string `"
 {"enabled": true, "time": "cpu"}
 {"enabled": true, "time": "itimer"}
 {"enabled": true, "time": "wall"}
-{"enabled": true, "time": "alloc", "alloc_interval": "512kb"}
+{"enabled": true, "time": "alloc", "alloc_interval": "512KiB"}
 {"enabled": true, "time": "auto"}
 {"enabled": false}
 ```

--- a/gprofiler/dynamic_profiling_management/__init__.py
+++ b/gprofiler/dynamic_profiling_management/__init__.py
@@ -5,6 +5,7 @@ import threading
 from pathlib import Path
 from typing import Dict, Any, Optional, TYPE_CHECKING
 
+import humanfriendly
 import configargparse
 
 if TYPE_CHECKING:
@@ -33,6 +34,10 @@ PROFILER_TYPE_MAP = {
 }
 
 ALL_PROFILER_TYPES = {"perf", "java", "python", "php", "ruby", "dotnet", "nodejs"}
+
+# Valid values for the async_profiler "time" config key.
+# Mirrors SUPPORTED_AP_MODES in java.py plus "auto" (which resolves cpu/itimer at runtime).
+_VALID_AP_TIME_MODES = frozenset({"cpu", "itimer", "wall", "auto", "alloc"})
 
 
 def get_enabled_profiler_types(profiling_command: Dict[str, Any]) -> set:
@@ -168,12 +173,38 @@ def _apply_profiler_configs(new_args: configargparse.Namespace, profiler_configs
         if not async_profiler_config.get("enabled", True):
             new_args.java_mode = "disabled"
         else:
-            new_args.java_async_profiler_mode = "wall" if async_profiler_config.get("time") == "wall" else "cpu"
+            time_mode = async_profiler_config.get("time", "cpu")
+            if time_mode not in _VALID_AP_TIME_MODES:
+                raise ValueError(
+                    f"Unknown async_profiler time mode {time_mode!r}. "
+                    f"Valid modes: {sorted(_VALID_AP_TIME_MODES)}"
+                )
+            if time_mode == "alloc":
+                # Allocation mode: profiling_mode drives _init_ap_mode to force alloc;
+                # frequency carries the alloc interval in bytes (as async-profiler expects).
+                new_args.profiling_mode = "allocation"
+                alloc_interval = async_profiler_config.get("alloc_interval", "2mb")
+                if not isinstance(alloc_interval, str) or not alloc_interval:
+                    raise ValueError(
+                        f"Invalid alloc_interval value {alloc_interval!r}: "
+                        "must be a non-empty string (e.g. '2mb', '512kb')"
+                    )
+                try:
+                    new_args.frequency = humanfriendly.parse_size(alloc_interval, binary=True)
+                except humanfriendly.InvalidSize as e:
+                    raise ValueError(
+                        f"Could not parse alloc_interval {alloc_interval!r}: {e}"
+                    ) from e
+            else:
+                new_args.java_async_profiler_mode = time_mode
     else:
         if async_profiler_config == "disabled":
             new_args.java_mode = "disabled"
         elif async_profiler_config == "enabled_wall":
-            new_args.java_async_profiler_mode = "itimer"
+            new_args.java_async_profiler_mode = "wall"
+        elif async_profiler_config == "enabled_alloc":
+            new_args.profiling_mode = "allocation"
+            new_args.frequency = humanfriendly.parse_size("2mb", binary=True)
         else:
             new_args.java_async_profiler_mode = "cpu"
 

--- a/gprofiler/dynamic_profiling_management/__init__.py
+++ b/gprofiler/dynamic_profiling_management/__init__.py
@@ -5,7 +5,7 @@ import threading
 from pathlib import Path
 from typing import Dict, Any, Optional, TYPE_CHECKING
 
-import humanfriendly
+import bitmath
 import configargparse
 
 if TYPE_CHECKING:
@@ -183,15 +183,15 @@ def _apply_profiler_configs(new_args: configargparse.Namespace, profiler_configs
                 # Allocation mode: profiling_mode drives _init_ap_mode to force alloc;
                 # frequency carries the alloc interval in bytes (as async-profiler expects).
                 new_args.profiling_mode = "allocation"
-                alloc_interval = async_profiler_config.get("alloc_interval", "2mb")
+                alloc_interval = async_profiler_config.get("alloc_interval", "2MB")
                 if not isinstance(alloc_interval, str) or not alloc_interval:
                     raise ValueError(
                         f"Invalid alloc_interval value {alloc_interval!r}: "
-                        "must be a non-empty string (e.g. '2mb', '512kb')"
+                        "must be a non-empty string (e.g. '2MB', '512KiB')"
                     )
                 try:
-                    new_args.frequency = humanfriendly.parse_size(alloc_interval, binary=True)
-                except humanfriendly.InvalidSize as e:
+                    new_args.frequency = int(bitmath.parse_string(alloc_interval).to_Byte())
+                except ValueError as e:
                     raise ValueError(
                         f"Could not parse alloc_interval {alloc_interval!r}: {e}"
                     ) from e
@@ -204,7 +204,7 @@ def _apply_profiler_configs(new_args: configargparse.Namespace, profiler_configs
             new_args.java_async_profiler_mode = "wall"
         elif async_profiler_config == "enabled_alloc":
             new_args.profiling_mode = "allocation"
-            new_args.frequency = humanfriendly.parse_size("2mb", binary=True)
+            new_args.frequency = int(bitmath.parse_string("2MB").to_Byte())
         else:
             new_args.java_async_profiler_mode = "cpu"
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,4 +12,5 @@ netifaces==0.11.0; sys.platform == "win32"
 WMI==1.5.1; sys.platform == "win32"
 ./granulate-utils/
 humanfriendly==10.0
+bitmath==2.1.1
 beautifulsoup4==4.13.3


### PR DESCRIPTION
# Support all async-profiler modes via the heartbeat dynamic profiling system

## Summary

The Java async-profiler mode was previously not fully controllable through the
heartbeat/dynamic profiling system. The `_apply_profiler_configs` function only
distinguished between `wall` and `cpu`, silently mapping every other mode to
`cpu`. This PR fixes that so all modes supported by async-profiler — including
allocation profiling — can be selected from the UI via a heartbeat profiling
command.

## Background

async-profiler supports several distinct profiling modes set via
`--java-async-profiler-mode`:

| Mode | Description |
|---|---|
| `cpu` | CPU time via `perf_events` |
| `itimer` | CPU time via `SIGPROF` (fallback when perf events unavailable) |
| `wall` | Wall-clock time (includes threads sleeping or waiting on I/O) |
| `alloc` | Allocation profiling — samples heap allocations, not CPU |
| `auto` | Selects `cpu` if perf events are available; otherwise `itimer` |

Allocation mode is special: it requires `profiling_mode = "allocation"` on the
gProfiler args namespace (not just `java_async_profiler_mode = "alloc"`), and
the sampling interval is expressed in bytes rather than nanoseconds. This
coupling between `profiling_mode` and the profiler-specific mode argument was not
handled in the dynamic profiling path at all.

## Changes

### `gprofiler/dynamic_profiling_management/__init__.py`

**New module-level constant `_VALID_AP_TIME_MODES`**

A `frozenset` of all valid values for the `time` field in an `async_profiler`
heartbeat config. Acts as a single maintenance point if async-profiler adds
new modes.

```python
_VALID_AP_TIME_MODES = frozenset({"cpu", "itimer", "wall", "auto", "alloc"})
```

**`_apply_profiler_configs` — dict branch**

| Before | After |
|---|---|
| `wall` → `java_async_profiler_mode = "wall"`, everything else → `"cpu"` | All five modes handled individually |
| No allocation mode support | `alloc` sets `profiling_mode = "allocation"` and parses `alloc_interval` into bytes for `frequency` |
| Unknown `time` values silently fell through to `"cpu"` | Unknown `time` values raise `ValueError` |
| Bad `alloc_interval` was logged as a warning and replaced with default | Bad `alloc_interval` raises `ValueError` |

The `alloc_interval` field (e.g. `"512KiB"`, `"2MB"`) is parsed with
`bitmath.parse_string(...).to_Byte()` and stored as `new_args.frequency` in bytes,
which is how `JavaProfiler.__init__` expects it when `profiling_mode == "allocation"`.
`bitmath` supports standard SI (e.g. `"MB"`) and IEC (e.g. `"MiB"`) unit notation.

**`_apply_profiler_configs` — legacy string branch**

- `"enabled_wall"` was incorrectly mapped to `itimer`; corrected to `wall`.
- Added `"enabled_alloc"` for completeness, using the `"2MB"` default interval.

**Input validation approach**

Rather than logging a warning and silently falling back to a default mode,
invalid config values now raise `ValueError`. This propagates out of
`_start_profiler` before any profiler thread is created, preventing a profiling
run with misconfigured arguments. The `CommandManager` has no "failed" status
concept — raising is the correct way to abort a command.

### `docs/HEARTBEAT_SYSTEM_README.md`

The "Java Async Profiler" section was a minimal 3-bullet list. Replaced with:

- A field reference table for `enabled`, `time`, and the new `alloc_interval`
- A mode table listing all five `time` values and what they map to in async-profiler
- Copy-paste JSON examples for every mode
- A note documenting `"disabled"` as a backward-compatible string shorthand

## Heartbeat Command Examples

**Allocation profiling with a custom interval:**
```json
{
  "combined_config": {
    "profiler_configs": {
      "async_profiler": {"enabled": true, "time": "alloc", "alloc_interval": "512KiB"}
    }
  }
}
```

**Wall-clock profiling:**
```json
{
  "combined_config": {
    "profiler_configs": {
      "async_profiler": {"enabled": true, "time": "wall"}
    }
  }
}
```

**Auto mode (resolves at runtime based on perf event availability):**
```json
{
  "combined_config": {
    "profiler_configs": {
      "async_profiler": {"enabled": true, "time": "auto"}
    }
  }
}
```

## Backwards Compatibility

- All existing heartbeat commands using `{"enabled": true, "time": "cpu"}`,
  `{"enabled": true, "time": "wall"}`, or `{"enabled": false}` are unaffected.
- The `"disabled"` string shorthand remains supported.
- The `enabled_wall` string → `itimer` mapping is corrected to `wall`; this was
  a bug and the fix is intentional.

## Testing

- Verified that `time: "alloc"` with and without `alloc_interval` produces the
  correct `profiling_mode = "allocation"` and `frequency` (bytes) on `new_args`.
- Verified that invalid `time` values and malformed `alloc_interval` strings
  raise `ValueError` and do not start a profiler.
- Verified that all existing modes (`cpu`, `wall`, `itimer`, `auto`) pass through
  unchanged to `java_async_profiler_mode`.
