### PR TITLE
Capture Java thread names per-sample for Spark task attribution

### DIFF
--- a/gprofiler/profilers/java.py
+++ b/gprofiler/profilers/java.py
@@ -495,7 +495,7 @@ class AsyncProfiledProcess:
     Represents a process profiled with async-profiler.
     """
 
-    FORMAT_PARAMS = "ann,sig"
+    FORMAT_PARAMS = "ann,sig,threads"
     OUTPUT_FORMAT = "collapsed"
     OUTPUTS_MODE = 0o622  # readable by root, writable by all
 

--- a/scripts/async_profiler_build_shared.sh
+++ b/scripts/async_profiler_build_shared.sh
@@ -16,8 +16,8 @@
 #
 set -euo pipefail
 
-VERSION=v3.0g1_threadpool
-GIT_REV="7efecaa0c4c88002319c89d83beb124e730d090b"
+VERSION=v3.0g1
+GIT_REV="952b30f9d28aeb9cb9e418ed6f60772dfdf83e46"
 
 git clone --depth 1 -b "$VERSION" https://github.com/Granulate/async-profiler.git && cd async-profiler && git reset --hard "$GIT_REV"
 make all

--- a/scripts/async_profiler_build_shared.sh
+++ b/scripts/async_profiler_build_shared.sh
@@ -16,8 +16,8 @@
 #
 set -euo pipefail
 
-VERSION=v3.0g1
-GIT_REV="952b30f9d28aeb9cb9e418ed6f60772dfdf83e46"
+VERSION=v3.0g1_threadpool
+GIT_REV="7efecaa0c4c88002319c89d83beb124e730d090b"
 
 git clone --depth 1 -b "$VERSION" https://github.com/Granulate/async-profiler.git && cd async-profiler && git reset --hard "$GIT_REV"
 make all


### PR DESCRIPTION
## Summary

Enables accurate per-thread attribution in Java flamegraphs for workloads that **rename threads at runtime** — most importantly Spark executors, which rename their task-pool threads per task (e.g. `Executor task launch worker for task 21.0 in stage 492.0`).

Two changes:

- **`scripts/async_profiler_build_shared.sh`** — build async-profiler from the `v3.0g1_threadpool` branch ([Granulate/async-profiler#10](https://github.com/Granulate/async-profiler/pull/10), "capture thread names for every sample"). Stock `v3.0g1` records a thread's name only once, so long-lived Spark executor pool threads keep a stale task/stage label across their lifetime; the threadpool build re-reads the name at each sample.
- **`gprofiler/profilers/java.py`** — add `threads` to async-profiler's collapsed-output `FORMAT_PARAMS` so each sample is prefixed with its (now current) thread name.

## Why

The Spark-on-k8s per-thread profiling demo ([gprofiler-performance-studio#85](https://github.com/pinterest/gprofiler-performance-studio/pull/85)) relies on thread names to break flamegraphs down by Spark stage/task. With the stock build, attribution silently drifts as executors reuse pool threads for new tasks. This PR makes the thread-name labels trustworthy.

## Notes for reviewers

- This makes per-thread output **always on** for Java profiling (larger collapsed output / higher frame cardinality). If we'd rather keep it opt-in, the `FORMAT_PARAMS` hunk can be dropped and `threads` passed via the existing `--java-async-profiler-args=threads` flag instead — the build-script change alone is what fixes stale names.
- The upstream async-profiler branch is an open POC PR on Granulate/async-profiler (not yet merged); we pin an exact `GIT_REV` so builds are reproducible.
- Branch history contains a couple of revert/reapply cycles; the net diff is just the two files above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)