### PR TITLE
Fix unbounded agent command queues

### DIFF
--- a/gprofiler/dynamic_profiling_management/command_control.py
+++ b/gprofiler/dynamic_profiling_management/command_control.py
@@ -50,27 +50,29 @@ class CommandManager:
         self.continuous_queue: Deque[ProfilingCommand] = deque()  # For continuous commands (continuous=True)
         self.queue_lock = threading.Lock()  # Thread-safe queue operations
 
-    def enqueue_command(self, command: ProfilingCommand) -> ProfilingCommand:
-        """Enqueue a command to the appropriate queue
+    def enqueue_command(self, command: ProfilingCommand) -> bool:
+        """Enqueue a command to the appropriate queue, enforcing queue size limits.
+
+        Stop and continuous commands are singleton slots: a new command replaces
+        any queued (not yet running) one, since the newest intent supersedes it.
+        Ad-hoc commands go to a bounded FIFO queue and are rejected when full.
 
         Args:
             command: ProfilingCommand object to enqueue
 
         Returns:
-            ProfilingCommand object that was enqueued
+            True if the command was enqueued, False if it was rejected
         """
-        # Add to appropriate queue
         with self.queue_lock:
             if command.command_type == "stop":
-                # Warn if stop queue exceeds limit
                 if len(self.stop_queue) >= STOP_QUEUE_MAX_SIZE:
-                    logger.warning(f"Stop queue exceeds limit (max: {STOP_QUEUE_MAX_SIZE}, current: {len(self.stop_queue)}), but adding command {command.command_id} anyway")
+                    logger.info(f"Replacing {len(self.stop_queue)} queued stop command(s) with new command {command.command_id}")
+                    self.stop_queue.clear()
 
                 self.stop_queue.append(command)
                 logger.info(f"Enqueued stop command {command.command_id} (queue size: {len(self.stop_queue)})")
             elif command.is_continuous:
-                # No need for warnings. The queue is always cleared before adding a new continuous command.
-                # Clear continuous queue before adding new continuous command
+                # Continuous is a singleton slot: clear before adding the new command
                 if self.continuous_queue:
                     logger.info(f"Clearing {len(self.continuous_queue)} existing continuous commands before adding new command {command.command_id}")
                     self.continuous_queue.clear()
@@ -78,14 +80,14 @@ class CommandManager:
                 self.continuous_queue.append(command)
                 logger.info(f"Enqueued continuous command {command.command_id} (queue size: {len(self.continuous_queue)})")
             else:
-                # Warn if ad-hoc queue exceeds limit
                 if len(self.adhoc_queue) >= ADHOC_QUEUE_MAX_SIZE:
-                    logger.warning(f"Ad-hoc queue exceeds limit (max: {ADHOC_QUEUE_MAX_SIZE}, current: {len(self.adhoc_queue)}), but adding command {command.command_id} anyway")
+                    logger.warning(f"Ad-hoc queue is full (max: {ADHOC_QUEUE_MAX_SIZE}), rejecting command {command.command_id}")
+                    return False
 
                 self.adhoc_queue.append(command)
                 logger.info(f"Enqueued ad-hoc command {command.command_id} (queue size: {len(self.adhoc_queue)})")
 
-        return command
+        return True
 
     def get_next_command(self) -> Optional[ProfilingCommand]:
         """Peek at the next command to execute based on priority logic without removing it.

--- a/gprofiler/dynamic_profiling_management/heartbeat.py
+++ b/gprofiler/dynamic_profiling_management/heartbeat.py
@@ -332,7 +332,14 @@ class DynamicGProfilerManager:
             timestamp=datetime.datetime.now(),
             is_paused=False,
         )
-        self.command_manager.enqueue_command(cmd)
+        if not self.command_manager.enqueue_command(cmd):
+            logger.warning(f"Command {command_id} rejected: queue is full")
+            self.heartbeat_client.send_command_completion(
+                command_id=command_id,
+                status="failed",
+                execution_time=0,
+                error_message="Agent command queue is full",
+            )
 
     def _process_command(self, cmd: ProfilingCommand) -> None:
         if cmd.command_type == "stop":

--- a/tests_fast/test_command_queue_spec.py
+++ b/tests_fast/test_command_queue_spec.py
@@ -50,6 +50,8 @@ _spec.loader.exec_module(command_control)
 
 CommandManager = command_control.CommandManager
 ProfilingCommand = command_control.ProfilingCommand
+ADHOC_QUEUE_MAX_SIZE = command_control.ADHOC_QUEUE_MAX_SIZE
+STOP_QUEUE_MAX_SIZE = command_control.STOP_QUEUE_MAX_SIZE
 
 
 def _cmd(command_id, command_type="start", is_continuous=False, profiling_command=None):
@@ -101,6 +103,32 @@ class TestContinuousSingletonSpec:
         manager.enqueue_command(_cmd("cont-2", is_continuous=True))
         assert len(manager.continuous_queue) == 1
         assert manager.get_next_command().command_id == "cont-2"
+
+
+class TestQueueBoundsSpec:
+    def test_adhoc_queue_rejects_when_full(self, manager):
+        for i in range(ADHOC_QUEUE_MAX_SIZE):
+            assert manager.enqueue_command(_cmd(f"a{i}")) is True
+        assert manager.enqueue_command(_cmd("overflow")) is False
+        assert len(manager.adhoc_queue) == ADHOC_QUEUE_MAX_SIZE
+        # FIFO order preserved; the rejected command is not in the queue.
+        assert manager.get_next_command().command_id == "a0"
+        assert all(c.command_id != "overflow" for c in manager.adhoc_queue)
+
+    def test_adhoc_queue_accepts_again_after_dequeue(self, manager):
+        for i in range(ADHOC_QUEUE_MAX_SIZE):
+            manager.enqueue_command(_cmd(f"a{i}"))
+        assert manager.dequeue_command("a0") is True
+        assert manager.enqueue_command(_cmd("a-new")) is True
+
+    def test_new_stop_replaces_queued_stop(self, manager):
+        assert manager.enqueue_command(_cmd("stop-1", command_type="stop")) is True
+        assert manager.enqueue_command(_cmd("stop-2", command_type="stop")) is True
+        assert len(manager.stop_queue) == STOP_QUEUE_MAX_SIZE
+        assert manager.get_next_command().command_id == "stop-2"
+
+    def test_continuous_enqueue_reports_success(self, manager):
+        assert manager.enqueue_command(_cmd("cont", is_continuous=True)) is True
 
 
 class TestDequeueSpec:


### PR DESCRIPTION
## Problem

The agent's command queues in `dynamic_profiling_management/command_control.py` declared size limits (`STOP_QUEUE_MAX_SIZE = 1`, `ADHOC_QUEUE_MAX_SIZE = 10`) but never enforced them — `enqueue_command` only logged a warning and appended anyway:

> "Ad-hoc queue exceeds limit (max: 10, current: N), but adding command ... anyway"

If the agent is busy with a long-running command (or wedged), every heartbeat can append another command, so both the ad-hoc and stop queues grow without bound for the lifetime of the process. Besides memory growth, an operator retrying a stuck request piles up stale duplicate commands that all execute later, back to back.

## Fix

- **Ad-hoc queue** — enforce `ADHOC_QUEUE_MAX_SIZE` by rejecting new commands when full. `enqueue_command` now returns `bool`; on rejection the heartbeat manager reports a `failed` command completion (`"Agent command queue is full"`) to the server, so the request doesn't hang in pending — the operator sees the failure and can retry once the queue drains.
- **Stop queue** — treat as a singleton slot (same semantics the continuous queue already had): a newer stop command replaces any queued, not-yet-running one. Queued stops are subsumed by a newer stop, so replacing is strictly better than stacking duplicates.
- **Continuous queue** — unchanged (already bounded by its replace-on-enqueue behavior).

## Tests

Added `TestQueueBoundsSpec` to the existing fast suite `tests_fast/test_command_queue_spec.py`:

- ad-hoc queue rejects at capacity, preserves FIFO order, and does not contain the rejected command
- ad-hoc queue accepts again after a dequeue frees a slot
- a new stop command replaces the queued one
- enqueue returns `True` on success for all queue types

```
$ python3 -m pytest tests_fast/ -q
18 passed, 1 skipped
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)